### PR TITLE
Fix: Check non-exhaustible conditional returns using a `goto` mechanism

### DIFF
--- a/crates/lean_compiler/src/a_simplify_lang.rs
+++ b/crates/lean_compiler/src/a_simplify_lang.rs
@@ -2249,9 +2249,9 @@ impl SimpleLine {
             }
             Self::Panic => "panic".to_string(),
             Self::LocationReport { .. } => Default::default(),
-	    Self::Goto { label } => {
-		format!("goto_{}", label)
-	    }
+            Self::Goto { label } => {
+                format!("goto_{}", label)
+            }
         };
         format!("{spaces}{line_str}")
     }

--- a/crates/lean_compiler/src/b_compile_intermediate.rs
+++ b/crates/lean_compiler/src/b_compile_intermediate.rs
@@ -597,6 +597,22 @@ fn compile_lines(
                     location: *location,
                 });
             }
+            SimpleLine::Goto { label } => {
+                let goto_label = Label::Custom(label.clone());
+                instructions.push(IntermediateInstruction::Jump {
+                    dest: IntermediateValue::label(goto_label.clone()),
+                    updated_fp: None,
+                });
+
+                let remaining = compile_lines(
+                    &lines[i + 1..],
+                    compiler,
+                    final_jump,
+                    declared_vars
+                )?;
+		compiler.bytecode.insert(goto_label, remaining);
+                return Ok(instructions);
+            }
         }
     }
 
@@ -795,7 +811,8 @@ fn find_internal_vars(lines: &[SimpleLine]) -> BTreeSet<Var> {
             | SimpleLine::Print { .. }
             | SimpleLine::FunctionRet { .. }
             | SimpleLine::Precompile { .. }
-            | SimpleLine::LocationReport { .. } => {}
+            | SimpleLine::LocationReport { .. }
+            | SimpleLine::Goto { .. } => {}
         }
     }
     internal_vars

--- a/crates/lean_compiler/src/b_compile_intermediate.rs
+++ b/crates/lean_compiler/src/b_compile_intermediate.rs
@@ -604,13 +604,9 @@ fn compile_lines(
                     updated_fp: None,
                 });
 
-                let remaining = compile_lines(
-                    &lines[i + 1..],
-                    compiler,
-                    final_jump,
-                    declared_vars
-                )?;
-		compiler.bytecode.insert(goto_label, remaining);
+                let remaining =
+                    compile_lines(&lines[i + 1..], compiler, final_jump, declared_vars)?;
+                compiler.bytecode.insert(goto_label, remaining);
                 return Ok(instructions);
             }
         }

--- a/crates/lean_compiler/src/lang.rs
+++ b/crates/lean_compiler/src/lang.rs
@@ -367,7 +367,7 @@ pub enum Line {
         location: SourceLineNumber,
     },
     Goto {
-	label: String,
+        label: String,
     },
 }
 impl Display for Expression {
@@ -564,9 +564,9 @@ impl Line {
             }
             Self::Break => "break".to_string(),
             Self::Panic => "panic".to_string(),
-	    Self::Goto { label } => {
-		format!("goto_{}", label)
-	    }
+            Self::Goto { label } => {
+                format!("goto_{}", label)
+            }
         };
         format!("{spaces}{line_str}")
     }

--- a/crates/lean_compiler/src/lang.rs
+++ b/crates/lean_compiler/src/lang.rs
@@ -366,6 +366,9 @@ pub enum Line {
     LocationReport {
         location: SourceLineNumber,
     },
+    Goto {
+	label: String,
+    },
 }
 impl Display for Expression {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -561,6 +564,9 @@ impl Line {
             }
             Self::Break => "break".to_string(),
             Self::Panic => "panic".to_string(),
+	    Self::Goto { label } => {
+		format!("goto_{}", label)
+	    }
         };
         format!("{spaces}{line_str}")
     }

--- a/crates/lean_compiler/tests/test_compiler.rs
+++ b/crates/lean_compiler/tests/test_compiler.rs
@@ -453,7 +453,7 @@ fn inline_bug_mre() {
         retur3n 1;
     }
    "#;
-    
+
     compile_and_run(program, &[], &[], DEFAULT_NO_VEC_RUNTIME_MEMORY, false);
 }
 

--- a/crates/lean_compiler/tests/test_compiler.rs
+++ b/crates/lean_compiler/tests/test_compiler.rs
@@ -450,7 +450,7 @@ fn inline_bug_mre() {
         if a == 0 {
             return 0;
         }
-        retur3n 1;
+        return 1;
     }
    "#;
 

--- a/crates/lean_compiler/tests/test_compiler.rs
+++ b/crates/lean_compiler/tests/test_compiler.rs
@@ -438,23 +438,24 @@ fn test_match() {
     compile_and_run(program, &[], &[], DEFAULT_NO_VEC_RUNTIME_MEMORY, false);
 }
 
-// #[test]
-// fn inline_bug_mre() {
-//     let program = r#"
-//     fn main() {
-//         boolean(0);
-//         return;
-//     }
+#[test]
+fn inline_bug_mre() {
+    let program = r#"
+    fn main() {
+        x = boolean(0);
+        return;
+    }
 
-//     fn boolean(a) inline -> 1 {
-//         if a == 0 {
-//             return 0;
-//         }
-//         return 1;
-//     }
-//    "#;
-//     compile_and_run(program, &[], &[]);
-// }
+    fn boolean(a) inline -> 1 {
+        if a == 0 {
+            return 0;
+        }
+        retur3n 1;
+    }
+   "#;
+    
+    compile_and_run(program, &[], &[], DEFAULT_NO_VEC_RUNTIME_MEMORY, false);
+}
 
 #[test]
 fn test_const_functions_calling_const_functions() {


### PR DESCRIPTION
Fixes #54.

I've added a `goto` mechanism, that adds explicit jump instructions to handle early returns in inlined functions. When an inline function has a `return` statement inside a conditional branch that doesn't cover all code paths, the mechanism ensures that execution jumps to the end of the inlined function body (the "epilogue") instead of continuing to execute subsequent code.

The mechanism operates at two levels:

1. At the Line level (during inlining): When `inline_lines()` encounters a `Line::FunctionRet` statement, it now:

- Converts the return into assignments (as before)
- Inserts a `Line::Goto instruction` that jumps to a unique epilogue label (e.g.,`@inline_epilogue_0`)

3. At the `SimpleLine` level (during simplification): The `Line::Goto` is converted to `SimpleLine::Goto` when the program is simplified.

4. At the intermediate bytecode level: `The SimpleLine::Goto` compiles to an unconditional `IntermediateInstruction::Jump` to the epilogue label, and the remaining code after the `got`o is registered in the bytecode map with that label.

Running the previously buggy `inline_bug_mre` test with `print` statements enabled in `lib.rs`, we get:

```shell
[divya@archdivya leanMultisig]$ RUST_BACKTRACE=1 cargo test -p lean_compiler inline_bug_mre -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.04s
     Running unittests src/lib.rs (target/debug/deps/lean_compiler-a1c9bc5cce5d53bb)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s

     Running tests/test_compiler.rs (target/debug/deps/test_compiler-bc0011693c4ca4dc)

running 1 test
Parsed program: fn boolean(a) -> 0 {
    
    if a == 0 {
        
        return 0
    }
    
    return 1
}
fn main() -> 0 {
    
    x = boolean(0)
    
    return 
}
Simplified program: fn main() -> 0 {
    
    
    @diff_0 = 0 - 0
    if @diff_0 != 0 {

    } else {
        
        x = 0 + 0
        goto_@inline_epilogue_0
    }
    
    x = 1 + 0
    goto_@inline_epilogue_0
    
    return 
}
Intermediate Bytecode:


@function_main:
  
  
  0 = m[fp + 2] + 0
  m[fp + 4] = inverse(m[fp + 2])
  m[fp + 5] = m[fp + 2] x m[fp + 4]
  1 = m[fp + 6] + m[fp + 5]
  0 = m[fp + 6] x m[fp + 2]
  jump_if_not_zero m[fp + 5] to @if_0
  jump @else_0

@if_0:
  jump @if_else_end_0

@else_0:
  
  m[fp + 3] = 0 + 0
  jump @inline_epilogue_0

@if_else_end_0:
  
  m[fp + 3] = 1 + 0
  jump @inline_epilogue_0

@inline_epilogue_0:
  
  m[fp + 7] = 0 + 0
  jump @end_program with fp = m[fp + 7]

Memory size per function:
main: 8

Function Locations: 

main: 2
boolean: 7


Compiled Program:

hint: label: @function_main
hint: source line number: 3
hint: source line number: 8
   0: 0 = 0 + m[fp + 2]
hint: m[fp + 4] = inverse(m[fp + 2])
   1: m[fp + 5] = m[fp + 2] x m[fp + 4]
   2: 1 = m[fp + 6] + m[fp + 5]
   3: 0 = m[fp + 6] x m[fp + 2]
   4: if m[fp + 5] != 0 jump to @if_0 = 7 with next(fp) = fp
   5: if 1 != 0 jump to @else_0 = 8 with next(fp) = fp
hint: label: @end_program
   6: if 1 != 0 jump to @end_program = 6 with next(fp) = fp
hint: label: @if_0
   7: if 1 != 0 jump to @if_else_end_0 = 10 with next(fp) = fp
hint: label: @else_0
hint: source line number: 9
   8: 0 = 0 + m[fp + 3]
   9: if 1 != 0 jump to @inline_epilogue_0 = 12 with next(fp) = fp
hint: label: @if_else_end_0
hint: source line number: 11
  10: 1 = 0 + m[fp + 3]
  11: if 1 != 0 jump to @inline_epilogue_0 = 12 with next(fp) = fp
hint: label: @inline_epilogue_0
hint: source line number: 4
  12: 0 = 0 + m[fp + 7]
  13: if 1 != 0 jump to @end_program = 6 with next(fp) = m[fp + 7]

╔═════════════════════════════════════════════════════════════════════════╗
║                                 STATS                                   ║
╚═════════════════════════════════════════════════════════════════════════╝

CYCLES: 10
MEMORY: 73

Bytecode size: 14
Public input size: 0
Private input size: 0
Runtime memory: 25 (0.00% vec) (no vec mem: 0)
Memory usage: 88.0%

──────────────────────────────────────────────────────────────────────────

test inline_bug_mre ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 19 filtered out; finished in 0.00s

[divya@archdivya leanMultisig]$ 
```