### PR TITLE
WHIR: svo + split-eq, keeping Merkle / FFT padding opti, using 2 sumchecks

### DIFF
--- a/crates/backend/poly/src/point.rs
+++ b/crates/backend/poly/src/point.rs
@@ -88,6 +88,12 @@ where
         acc
     }
 
+    pub fn reversed(&self) -> Self {
+        let mut rev = self.0.clone();
+        rev.reverse();
+        Self(rev)
+    }
+
     /// Embeds the point into an extension field `EF`.
     #[must_use]
     pub fn embed<EF: ExtensionField<F>>(&self) -> MultilinearPoint<EF> {

--- a/crates/lean_prover/src/prove_execution.rs
+++ b/crates/lean_prover/src/prove_execution.rs
@@ -183,9 +183,15 @@ pub fn prove_execution(
         &committed_statements,
     );
 
+    let dense_claim = prove_reduction_many_sparse_claims_to_single_dense(
+        &mut prover_state,
+        &global_statements_base,
+        &stacked_pcs_witness.global_polynomial,
+    );
+
     WhirConfig::new(whir_config, stacked_pcs_witness.global_polynomial.by_ref().n_vars()).prove(
         &mut prover_state,
-        global_statements_base,
+        dense_claim,
         stacked_pcs_witness.inner_witness,
         &stacked_pcs_witness.global_polynomial.by_ref(),
     );

--- a/crates/lean_prover/src/verify_execution.rs
+++ b/crates/lean_prover/src/verify_execution.rs
@@ -149,12 +149,15 @@ pub fn verify_execution(
 
     // sanity check (not necessary for soundness)
     let num_whir_statements = global_statements_base.iter().map(|s| s.values.len()).sum::<usize>();
-    assert_eq!(num_whir_statements, total_whir_statements());
+    assert_eq!(num_whir_statements, total_sparse_statements());
+
+    let dense_claim =
+        verify_reduction_many_sparse_claims_to_single_dense(&mut verifier_state, &global_statements_base)?;
 
     WhirConfig::new(&whir_config, parsed_commitment.num_variables).verify(
         &mut verifier_state,
         &parsed_commitment,
-        global_statements_base,
+        dense_claim,
     )?;
 
     Ok((

--- a/crates/rec_aggregation/recursion.py
+++ b/crates/rec_aggregation/recursion.py
@@ -30,7 +30,7 @@ N_COMMITTED_EXEC_COLUMNS = N_COMMITTED_EXEC_COLUMNS_PLACEHOLDER
 
 LOG_GUEST_BYTECODE_LEN = LOG_GUEST_BYTECODE_LEN_PLACEHOLDER
 COL_PC = COL_PC_PLACEHOLDER
-TOTAL_WHIR_STATEMENTS = TOTAL_WHIR_STATEMENTS_PLACEHOLDER
+TOTAL_SPARSE_STATEMENTS = TOTAL_SPARSE_STATEMENTS_PLACEHOLDER
 STARTING_PC = STARTING_PC_PLACEHOLDER
 ENDING_PC = ENDING_PC_PLACEHOLDER
 BYTECODE_POINT_N_VARS = LOG_GUEST_BYTECODE_LEN + log2_ceil(N_INSTRUCTION_COLUMNS)
@@ -447,26 +447,23 @@ def continue_recursion_ordered(
     public_memory_eval = Array(DIM)
     dot_product_be_const(inner_public_memory, poly_eq_public_mem, public_memory_eval, 2**INNER_PUBLIC_MEMORY_LOG_SIZE)
 
-    # WHIR BASE
-    combination_randomness_gen: Mut
-    fs, combination_randomness_gen = fs_sample_ef(fs)
-    combination_randomness_powers: Mut = powers(combination_randomness_gen, num_ood_at_commitment + TOTAL_WHIR_STATEMENTS)
-    whir_sum: Mut = Array(DIM)
-    dot_product_ee_dynamic(whir_base_ood_evals, combination_randomness_powers, whir_sum, num_ood_at_commitment)
-    curr_randomness: Mut = combination_randomness_powers + num_ood_at_commitment * DIM
+    # reduce all sparse claims to a single dense claim
+    fs, gamma = fs_sample_ef(fs)
+    gamma_powers: Mut = powers_const(gamma, TOTAL_SPARSE_STATEMENTS)
+    pre_whir_claimed_sum: Mut = Array(DIM)
+    curr_randomness: Mut = gamma_powers
 
-    whir_sum = add_extension_ret(mul_extension_ret(value_memory, curr_randomness), whir_sum)
+    pre_whir_claimed_sum = mul_extension_ret(value_memory, curr_randomness)
     curr_randomness += DIM
-    whir_sum = add_extension_ret(mul_extension_ret(value_acc, curr_randomness), whir_sum)
+    pre_whir_claimed_sum = add_extension_ret(mul_extension_ret(value_acc, curr_randomness), pre_whir_claimed_sum)
     curr_randomness += DIM
-    whir_sum = add_extension_ret(mul_extension_ret(public_memory_eval, curr_randomness), whir_sum)
+    pre_whir_claimed_sum = add_extension_ret(mul_extension_ret(public_memory_eval, curr_randomness), pre_whir_claimed_sum)
     curr_randomness += DIM
-    whir_sum = add_extension_ret(mul_extension_ret(value_bytecode_acc, curr_randomness), whir_sum)
+    pre_whir_claimed_sum = add_extension_ret(mul_extension_ret(value_bytecode_acc, curr_randomness), pre_whir_claimed_sum)
     curr_randomness += DIM
-
-    whir_sum = add_extension_ret(mul_extension_ret(embed_in_ef(STARTING_PC), curr_randomness), whir_sum)
+    pre_whir_claimed_sum = add_extension_ret(mul_extension_ret(embed_in_ef(STARTING_PC), curr_randomness), pre_whir_claimed_sum)
     curr_randomness += DIM
-    whir_sum = add_extension_ret(mul_extension_ret(embed_in_ef(ENDING_PC), curr_randomness), whir_sum)
+    pre_whir_claimed_sum = add_extension_ret(mul_extension_ret(embed_in_ef(ENDING_PC), curr_randomness), pre_whir_claimed_sum)
     curr_randomness += DIM
 
     for sorted_pos in unroll(0, N_TABLES):
@@ -482,55 +479,42 @@ def continue_recursion_ordered(
             for j in unroll(0, len(pcs_values[table_index][i])):
                 debug_assert(len(pcs_values[table_index][i][j]) < 2)
                 if len(pcs_values[table_index][i][j]) == 1:
-                    whir_sum = add_extension_ret(
+                    pre_whir_claimed_sum = add_extension_ret(
                         mul_extension_ret(pcs_values[table_index][i][j][0], curr_randomness),
-                        whir_sum,
+                        pre_whir_claimed_sum,
                     )
                     curr_randomness += DIM
 
-    folding_randomness_global: Mut
-    s: Mut
-    final_value: Mut
-    end_sum: Mut
-    fs, folding_randomness_global, s, final_value, end_sum = whir_open(
-        fs,
-        stacked_n_vars,
-        whir_log_inv_rate,
-        whir_base_root,
-        whir_base_ood_points,
-        combination_randomness_powers,
-        whir_sum,
-    )
+    fs, pre_whir_point, pre_whir_final_sum = sumcheck_verify(fs, stacked_n_vars, pre_whir_claimed_sum, 2)
 
-    curr_randomness = combination_randomness_powers + num_ood_at_commitment * DIM
+    # Compute W(r) at pre_whir_point
+    curr_randomness = gamma_powers
+    w_eval: Mut = Array(DIM)
 
     eq_memory_and_acc_point = eq_mle_extension(
-        folding_randomness_global + (stacked_n_vars - log_memory) * DIM,
+        pre_whir_point + (stacked_n_vars - log_memory) * DIM,
         memory_and_acc_point,
         log_memory,
     )
-    prefix_memory = multilinear_location_prefix(0, stacked_n_vars - log_memory, folding_randomness_global)
-    s = add_extension_ret(
-        s,
-        mul_extension_ret(mul_extension_ret(curr_randomness, prefix_memory), eq_memory_and_acc_point),
-    )
+    prefix_memory = multilinear_location_prefix(0, stacked_n_vars - log_memory, pre_whir_point)
+    w_eval = mul_extension_ret(mul_extension_ret(curr_randomness, prefix_memory), eq_memory_and_acc_point)
     curr_randomness += DIM
 
-    prefix_acc_memory = multilinear_location_prefix(1, stacked_n_vars - log_memory, folding_randomness_global)
-    s = add_extension_ret(
-        s,
+    prefix_acc_memory = multilinear_location_prefix(1, stacked_n_vars - log_memory, pre_whir_point)
+    w_eval = add_extension_ret(
+        w_eval,
         mul_extension_ret(mul_extension_ret(curr_randomness, prefix_acc_memory), eq_memory_and_acc_point),
     )
     curr_randomness += DIM
 
     eq_pub_mem = eq_mle_extension(
-        folding_randomness_global + (stacked_n_vars - INNER_PUBLIC_MEMORY_LOG_SIZE) * DIM,
+        pre_whir_point + (stacked_n_vars - INNER_PUBLIC_MEMORY_LOG_SIZE) * DIM,
         public_memory_random_point,
         INNER_PUBLIC_MEMORY_LOG_SIZE,
     )
-    prefix_pub_mem = multilinear_location_prefix(0, stacked_n_vars - INNER_PUBLIC_MEMORY_LOG_SIZE, folding_randomness_global)
-    s = add_extension_ret(
-        s,
+    prefix_pub_mem = multilinear_location_prefix(0, stacked_n_vars - INNER_PUBLIC_MEMORY_LOG_SIZE, pre_whir_point)
+    w_eval = add_extension_ret(
+        w_eval,
         mul_extension_ret(mul_extension_ret(curr_randomness, prefix_pub_mem), eq_pub_mem),
     )
     curr_randomness += DIM
@@ -538,17 +522,17 @@ def continue_recursion_ordered(
     offset = two_exp(log_memory) * 2  # memory and acc_memory
 
     eq_bytecode_acc = eq_mle_extension(
-        folding_randomness_global + (stacked_n_vars - LOG_GUEST_BYTECODE_LEN) * DIM,
+        pre_whir_point + (stacked_n_vars - LOG_GUEST_BYTECODE_LEN) * DIM,
         bytecode_and_acc_point,
         LOG_GUEST_BYTECODE_LEN,
     )
     prefix_bytecode_acc = multilinear_location_prefix(
         offset / 2**LOG_GUEST_BYTECODE_LEN,
         stacked_n_vars - LOG_GUEST_BYTECODE_LEN,
-        folding_randomness_global,
+        pre_whir_point,
     )
-    s = add_extension_ret(
-        s,
+    w_eval = add_extension_ret(
+        w_eval,
         mul_extension_ret(mul_extension_ret(curr_randomness, prefix_bytecode_acc), eq_bytecode_acc),
     )
     curr_randomness += DIM
@@ -557,17 +541,17 @@ def continue_recursion_ordered(
     prefix_pc_start = multilinear_location_prefix(
         offset + COL_PC * two_exp(log_n_cycles),
         stacked_n_vars,
-        folding_randomness_global,
+        pre_whir_point,
     )
-    s = add_extension_ret(s, mul_extension_ret(curr_randomness, prefix_pc_start))
+    w_eval = add_extension_ret(w_eval, mul_extension_ret(curr_randomness, prefix_pc_start))
     curr_randomness += DIM
 
     prefix_pc_end = multilinear_location_prefix(
         offset + (COL_PC + 1) * two_exp(log_n_cycles) - 1,
         stacked_n_vars,
-        folding_randomness_global,
+        pre_whir_point,
     )
-    s = add_extension_ret(s, mul_extension_ret(curr_randomness, prefix_pc_end))
+    w_eval = add_extension_ret(w_eval, mul_extension_ret(curr_randomness, prefix_pc_end))
     curr_randomness += DIM
 
     for sorted_pos in unroll(0, N_TABLES):
@@ -585,7 +569,7 @@ def continue_recursion_ordered(
             point = pcs_points[table_index][i]
             eq_factor = eq_mle_extension(
                 point,
-                folding_randomness_global + (stacked_n_vars - log_n_rows) * DIM,
+                pre_whir_point + (stacked_n_vars - log_n_rows) * DIM,
                 log_n_rows,
             )
             for j in unroll(0, total_num_cols):
@@ -593,14 +577,47 @@ def continue_recursion_ordered(
                     prefix = multilinear_location_prefix(
                         offset / n_rows + j,
                         stacked_n_vars - log_n_rows,
-                        folding_randomness_global,
+                        pre_whir_point,
                     )
-                    s = add_extension_ret(
-                        s,
+                    w_eval = add_extension_ret(
+                        w_eval,
                         mul_extension_ret(mul_extension_ret(curr_randomness, prefix), eq_factor),
                     )
                     curr_randomness += DIM
         offset += n_rows * total_num_cols
+
+    p_eval = div_extension_ret(pre_whir_final_sum, w_eval)
+
+    # WHIR with single dense claim
+    combination_randomness_gen: Mut
+    fs, combination_randomness_gen = fs_sample_ef(fs)
+    combination_randomness_powers: Mut = powers(combination_randomness_gen, num_ood_at_commitment + 1)
+    whir_sum: Mut = Array(DIM)
+    dot_product_ee_dynamic(whir_base_ood_evals, combination_randomness_powers, whir_sum, num_ood_at_commitment)
+    whir_sum = add_extension_ret(
+        mul_extension_ret(p_eval, combination_randomness_powers + num_ood_at_commitment * DIM),
+        whir_sum,
+    )
+
+    folding_randomness_global: Imu
+    s: Mut
+    final_value: Imu
+    end_sum: Imu
+    fs, folding_randomness_global, s, final_value, end_sum = whir_open(
+        fs,
+        stacked_n_vars,
+        whir_log_inv_rate,
+        whir_base_root,
+        whir_base_ood_points,
+        combination_randomness_powers,
+        whir_sum,
+    )
+
+    eq_dense = eq_mle_extension(pre_whir_point, folding_randomness_global, stacked_n_vars)
+    s = add_extension_ret(
+        s,
+        mul_extension_ret(combination_randomness_powers + num_ood_at_commitment * DIM, eq_dense),
+    )
 
     copy_5(mul_extension_ret(s, final_value), end_sum)
     return

--- a/crates/rec_aggregation/recursion.py
+++ b/crates/rec_aggregation/recursion.py
@@ -485,7 +485,12 @@ def continue_recursion_ordered(
                     )
                     curr_randomness += DIM
 
-    fs, pre_whir_point, pre_whir_final_sum = sumcheck_verify(fs, stacked_n_vars, pre_whir_claimed_sum, 2)
+    fs, pre_whir_challenges, pre_whir_final_sum = sumcheck_verify(fs, stacked_n_vars, pre_whir_claimed_sum, 2)
+
+    # Reverse challenges: sumcheck folded variables right-to-left
+    pre_whir_point = Array(stacked_n_vars * DIM)
+    for i in range(0, stacked_n_vars):
+        copy_5(pre_whir_challenges + i * DIM, pre_whir_point + (stacked_n_vars - 1 - i) * DIM)
 
     # Compute W(r) at pre_whir_point
     curr_randomness = gamma_powers

--- a/crates/rec_aggregation/src/compilation.rs
+++ b/crates/rec_aggregation/src/compilation.rs
@@ -8,7 +8,7 @@ use lean_vm::*;
 use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 use std::sync::OnceLock;
-use sub_protocols::{min_stacked_n_vars, total_whir_statements};
+use sub_protocols::{min_stacked_n_vars, total_sparse_statements};
 use tracing::instrument;
 use utils::Counter;
 use xmss::{LOG_LIFETIME, MESSAGE_LEN_FE, RANDOMNESS_LEN_FE, TARGET_SUM, V, V_GRINDING, W};
@@ -336,8 +336,8 @@ fn build_replacements(
         N_RUNTIME_COLUMNS.to_string(),
     );
     replacements.insert(
-        "TOTAL_WHIR_STATEMENTS_PLACEHOLDER".to_string(),
-        total_whir_statements().to_string(),
+        "TOTAL_SPARSE_STATEMENTS_PLACEHOLDER".to_string(),
+        total_sparse_statements().to_string(),
     );
     replacements.insert("STARTING_PC_PLACEHOLDER".to_string(), STARTING_PC.to_string());
     replacements.insert("ENDING_PC_PLACEHOLDER".to_string(), ENDING_PC.to_string());

--- a/crates/sub_protocols/src/lib.rs
+++ b/crates/sub_protocols/src/lib.rs
@@ -7,4 +7,7 @@ pub use stacked_pcs::*;
 mod quotient_gkr;
 pub use quotient_gkr::*;
 
+mod reduce_claims;
+pub use reduce_claims::*;
+
 pub(crate) const MIN_VARS_FOR_PACKING: usize = 8;

--- a/crates/sub_protocols/src/reduce_claims.rs
+++ b/crates/sub_protocols/src/reduce_claims.rs
@@ -106,6 +106,7 @@ pub fn prove_reduction_many_sparse_claims_to_single_dense(
 /// Precomputes eq_svo tables, accumulators, and weight metadata for all claims.
 /// Returns parallel arrays: one entry per "merged claim group" (= per SparseStatement
 /// when all selector bits fit in the lo-half, otherwise per SparseValue).
+#[allow(clippy::type_complexity)]
 fn precompute(
     statements: &[SparseStatement<EF>],
     gamma: EF,
@@ -128,6 +129,7 @@ fn precompute(
     let gamma_pows: Vec<EF> = gamma.powers().collect_n(offset);
 
     // Each statement produces one or more (eq_svo, accumulator, weight_info) entries.
+    #[allow(clippy::type_complexity)]
     let groups: Vec<Vec<(Vec<EF>, Vec<EF>, (Vec<EF>, Vec<(EF, usize)>))>> = statements
         .par_iter()
         .enumerate()

--- a/crates/sub_protocols/src/reduce_claims.rs
+++ b/crates/sub_protocols/src/reduce_claims.rs
@@ -1,0 +1,148 @@
+use backend::*;
+use lean_vm::EF;
+use tracing::instrument;
+
+use crate::*;
+
+#[instrument(skip_all, fields(n_claims = statements.len(), n_vars = statements[0].total_num_variables))]
+pub fn prove_reduction_many_sparse_claims_to_single_dense(
+    prover_state: &mut impl FSProver<EF>,
+    statements: &[SparseStatement<EF>],
+    polynomial: &MleOwned<EF>,
+) -> Evaluation<EF> {
+    let n_vars = statements[0].total_num_variables;
+    assert!(statements.iter().all(|s| s.total_num_variables == n_vars));
+
+    let gamma: EF = prover_state.sample();
+    let (weights, sum) = combine_sparse_statements(statements, gamma);
+    let weights_mle = MleOwned::ExtensionPacked(weights);
+    let packed_poly = polynomial.pack();
+    let packed_poly_ref = packed_poly.by_ref();
+    let weights_ref = weights_mle.by_ref();
+    let (challenges, _final_sum, folded_poly, _folded_weights) =
+        run_product_sumcheck(&packed_poly_ref, &weights_ref, prover_state, sum, n_vars, 0);
+
+    let p_eval = folded_poly.evaluate(&MultilinearPoint(vec![]));
+
+    Evaluation::new(challenges, p_eval)
+}
+
+pub fn verify_reduction_many_sparse_claims_to_single_dense(
+    verifier_state: &mut impl FSVerifier<EF>,
+    statements: &[SparseStatement<EF>],
+) -> Result<Evaluation<EF>, ProofError> {
+    let n_vars = statements[0].total_num_variables;
+    assert!(statements.iter().all(|s| s.total_num_variables == n_vars));
+
+    let gamma: EF = verifier_state.sample();
+
+    let mut claimed_sum = EF::ZERO;
+    let mut gamma_pow = EF::ONE;
+    for smt in statements {
+        for e in &smt.values {
+            claimed_sum += gamma_pow * e.value;
+            gamma_pow *= gamma;
+        }
+    }
+
+    let Evaluation {
+        point: challenges,
+        value: final_claimed_sum,
+    } = sumcheck_verify(verifier_state, n_vars, 2, claimed_sum, None)?;
+
+    let w_eval = eval_combined_sparse_weights(statements, gamma, &challenges);
+    let p_eval = final_claimed_sum / w_eval;
+
+    Ok(Evaluation::new(challenges, p_eval))
+}
+
+fn eval_combined_sparse_weights(statements: &[SparseStatement<EF>], gamma: EF, point: &MultilinearPoint<EF>) -> EF {
+    let mut value = EF::ZERO;
+    let mut gamma_pow = EF::ONE;
+
+    for smt in statements {
+        let inner_eq = smt.point.eq_poly_outside(&MultilinearPoint(
+            point[point.len() - smt.inner_num_variables()..].to_vec(),
+        ));
+        let sel_n_vars = smt.selector_num_variables();
+        for e in &smt.values {
+            let selector_eq: EF = (0..sel_n_vars)
+                .map(|j| {
+                    if e.selector & (1 << (sel_n_vars - 1 - j)) == 0 {
+                        EF::ONE - point[j]
+                    } else {
+                        point[j]
+                    }
+                })
+                .product();
+            value += gamma_pow * selector_eq * inner_eq;
+            gamma_pow *= gamma;
+        }
+    }
+
+    value
+}
+
+#[instrument(skip_all, fields(num_constraints = statements.len(), n_vars = statements[0].total_num_variables))]
+pub fn combine_sparse_statements<EF>(statements: &[SparseStatement<EF>], gamma: EF) -> (Vec<EFPacking<EF>>, EF)
+where
+    EF: ExtensionField<PF<EF>>,
+{
+    let num_variables = statements[0].total_num_variables;
+    assert!(statements.iter().all(|e| e.total_num_variables == num_variables));
+
+    let mut combined_weights = EFPacking::<EF>::zero_vec(1 << (num_variables - packing_log_width::<EF>()));
+
+    let mut combined_sum = EF::ZERO;
+    let mut gamma_pow = EF::ONE;
+
+    for smt in statements {
+        if smt.values.len() == 1 || smt.inner_num_variables() < packing_log_width::<EF>() {
+            for evaluation in &smt.values {
+                compute_sparse_eval_eq_packed::<EF>(evaluation.selector, &smt.point, &mut combined_weights, gamma_pow);
+                combined_sum += evaluation.value * gamma_pow;
+                gamma_pow *= gamma;
+            }
+        } else {
+            let poly_eq = eval_eq_packed(&smt.point);
+            let shift = smt.inner_num_variables() - packing_log_width::<EF>();
+            let mut indexed_smt_values = smt.values.iter().enumerate().collect::<Vec<_>>();
+            indexed_smt_values.sort_by_key(|(_, e)| e.selector);
+            indexed_smt_values.dedup_by_key(|(_, e)| e.selector);
+            assert_eq!(
+                indexed_smt_values.len(),
+                smt.values.len(),
+                "Duplicate selectors in sparse statement"
+            );
+            let mut chunks_mut = split_at_mut_many(
+                &mut combined_weights,
+                &indexed_smt_values
+                    .iter()
+                    .map(|(_, e)| e.selector << shift)
+                    .collect::<Vec<_>>(),
+            );
+            chunks_mut.remove(0);
+            let mut next_gamma_powers = vec![gamma_pow];
+            for _ in 1..indexed_smt_values.len() {
+                next_gamma_powers.push(*next_gamma_powers.last().unwrap() * gamma);
+            }
+            for (e, &scalar) in smt.values.iter().zip(&next_gamma_powers) {
+                combined_sum += e.value * scalar;
+            }
+            chunks_mut
+                .into_par_iter()
+                .zip(&indexed_smt_values)
+                .for_each(|(out_buff, &(origin_index, _))| {
+                    out_buff[..1 << shift]
+                        .par_iter_mut()
+                        .zip(&poly_eq)
+                        .for_each(|(out_elem, &poly_eq_elem)| {
+                            *out_elem += poly_eq_elem * next_gamma_powers[origin_index];
+                        });
+                });
+            gamma_pow = *next_gamma_powers.last().unwrap() * gamma;
+        }
+    }
+
+    (combined_weights, combined_sum)
+}

--- a/crates/sub_protocols/src/reduce_claims.rs
+++ b/crates/sub_protocols/src/reduce_claims.rs
@@ -1,8 +1,12 @@
 use backend::*;
-use lean_vm::EF;
-use tracing::instrument;
+use lean_vm::{EF, F};
+use tracing::{info_span, instrument};
 
 use crate::*;
+
+/*
+Details: https://github.com/TomWambsgans/misc/blob/master/pcs_in_2_sumchecks.pdf
+*/
 
 #[instrument(skip_all, fields(n_claims = statements.len(), n_vars = statements[0].total_num_variables))]
 pub fn prove_reduction_many_sparse_claims_to_single_dense(
@@ -10,139 +14,252 @@ pub fn prove_reduction_many_sparse_claims_to_single_dense(
     statements: &[SparseStatement<EF>],
     polynomial: &MleOwned<EF>,
 ) -> Evaluation<EF> {
-    let n_vars = statements[0].total_num_variables;
-    assert!(statements.iter().all(|s| s.total_num_variables == n_vars));
+    let l = statements[0].total_num_variables;
+    assert!(l >= 2);
+    assert!(statements.iter().all(|s| s.total_num_variables == l));
 
     let gamma: EF = prover_state.sample();
-    let (weights, sum) = combine_sparse_statements(statements, gamma);
-    let weights_mle = MleOwned::ExtensionPacked(weights);
-    let packed_poly = polynomial.pack();
-    let packed_poly_ref = packed_poly.by_ref();
-    let weights_ref = weights_mle.by_ref();
-    let (challenges, _final_sum, folded_poly, _folded_weights) =
-        run_product_sumcheck(&packed_poly_ref, &weights_ref, prover_state, sum, n_vars, 0);
+    let y_alpha = claimed_sum(statements, gamma);
+    let f = polynomial.as_base().unwrap();
+    let l0 = l - l / 2; // number of SVO rounds = ceil(l/2)
+    let n_lo = 1usize << (l / 2);
+    let n_hi = 1usize << l0;
 
-    let p_eval = folded_poly.evaluate(&MultilinearPoint(vec![]));
+    // --- Precompute per-claim data ---
+    // For each claim i: eq_svo_i = eval_eq(w_i^hi), A_i[k] = sum_{b^lo} eq_lo_i[b^lo] * f(b^lo, k)
+    // Claims within a statement that share eq_svo are merged (accumulators summed with gamma weights).
+    let (mut eq_svos, mut accumulators, weight_info) =
+        info_span!("precompute").in_scope(|| precompute(statements, gamma, l, f, n_lo, n_hi));
 
-    Evaluation::new(challenges, p_eval)
+    // --- SVO rounds: fold X_l, X_{l-1}, ..., X_{l/2+1} (right-to-left = LSB first) ---
+    let mut challenges = Vec::with_capacity(l0);
+    let mut sum = y_alpha;
+
+    for _round in 0..l0 {
+        let mut c0 = EF::ZERO;
+        let mut c2 = EF::ZERO;
+        for (eq, acc) in eq_svos.iter().zip(&accumulators) {
+            let half = acc.len() / 2;
+            for j in 0..half {
+                c0 += eq[2 * j] * acc[2 * j];
+                c2 += (eq[2 * j + 1] - eq[2 * j]) * (acc[2 * j + 1] - acc[2 * j]);
+            }
+        }
+        let c1 = sum - c0 - c0 - c2;
+        let poly = DensePolynomial::new(vec![c0, c1, c2]);
+        prover_state.add_sumcheck_polynomial(&poly.coeffs, None);
+        let r: EF = prover_state.sample();
+        challenges.push(r);
+        sum = poly.evaluate(r);
+        for (eq, acc) in eq_svos.iter_mut().zip(accumulators.iter_mut()) {
+            fold_lsb(eq, r);
+            fold_lsb(acc, r);
+        }
+    }
+
+    // --- Post-SVO: fold f and build remaining weight for lo-half product sumcheck ---
+    let (mut f_folded, mut w_rest) = info_span!("post_svo").in_scope(|| {
+        // Multi-fold f at SVO challenges (right-to-left = fold LSBs)
+        let mut r_rev = challenges.clone();
+        r_rev.reverse();
+        let eq_at_r = eval_eq(&r_rev);
+        let mut f_folded = EF::zero_vec(n_lo);
+        f_folded.par_chunks_mut(64).enumerate().for_each(|(ci, chunk)| {
+            for (k, dest) in chunk.iter_mut().enumerate() {
+                let j = ci * 64 + k;
+                *dest = dot_product(eq_at_r.iter().copied(), f[j * n_hi..][..n_hi].iter().copied());
+            }
+        });
+
+        // Weight: w_rest[b^lo] = sum_claims eq_svo_scalar * gamma * eq_lo_ns[sparse_offset + b^lo_ns]
+        let mut w_rest = EF::zero_vec(n_lo);
+        for (eq_svo, (eq_lo, vals)) in eq_svos.iter().zip(&weight_info) {
+            let svo_scalar = eq_svo[0]; // fully folded to 1 entry
+            let n_ns = eq_lo.len();
+            for &(gp, sel_lo) in vals {
+                let scale = gp * svo_scalar;
+                let off = sel_lo * n_ns;
+                for (b, &v) in eq_lo.iter().enumerate() {
+                    w_rest[off + b] += scale * v;
+                }
+            }
+        }
+        (f_folded, w_rest)
+    });
+
+    // --- Remaining lo-half sumcheck via standard product sumcheck (right-to-left via bit-reverse) ---
+    bit_reverse_permutation(&mut f_folded);
+    bit_reverse_permutation(&mut w_rest);
+    let f_mle = MleOwned::Extension(f_folded);
+    let w_mle = MleOwned::Extension(w_rest);
+    let f_p = f_mle.pack();
+    let w_p = w_mle.pack();
+    let (rest_r, _, folded, _) = run_product_sumcheck(&f_p.by_ref(), &w_p.by_ref(), prover_state, sum, l / 2, 0);
+
+    let p_eval = folded.evaluate(&MultilinearPoint(vec![]));
+    let mut all_r: Vec<EF> = challenges;
+    all_r.extend(rest_r.0);
+    all_r.reverse();
+    Evaluation::new(all_r, p_eval)
+}
+
+/// Precomputes eq_svo tables, accumulators, and weight metadata for all claims.
+/// Returns parallel arrays: one entry per "merged claim group" (= per SparseStatement
+/// when all selector bits fit in the lo-half, otherwise per SparseValue).
+fn precompute(
+    statements: &[SparseStatement<EF>],
+    gamma: EF,
+    l: usize,
+    f: &[F],
+    _n_lo: usize,
+    n_hi: usize,
+) -> (
+    Vec<Vec<EF>>,                     // eq_svos
+    Vec<Vec<EF>>,                     // accumulators
+    Vec<(Vec<EF>, Vec<(EF, usize)>)>, // (eq_lo, per-value (gamma_pow, sel_lo))
+) {
+    let half = l / 2;
+    let mut starts = Vec::with_capacity(statements.len());
+    let mut offset = 0;
+    for smt in statements {
+        starts.push(offset);
+        offset += smt.values.len();
+    }
+    let gamma_pows: Vec<EF> = gamma.powers().collect_n(offset);
+
+    // Each statement produces one or more (eq_svo, accumulator, weight_info) entries.
+    let groups: Vec<Vec<(Vec<EF>, Vec<EF>, (Vec<EF>, Vec<(EF, usize)>))>> = statements
+        .par_iter()
+        .enumerate()
+        .map(|(si, smt)| {
+            let vi = starts[si];
+            let s = smt.selector_num_variables();
+            let s_lo = s.min(half);
+            let s_hi = s - s_lo;
+            let lo_ns = half - s_lo; // "lo non-sparse" = the number of non-sparse (extension field) variables in the lo-half part
+            let eq_lo = if lo_ns > 0 {
+                eval_eq(&smt.point[..lo_ns])
+            } else {
+                vec![EF::ONE]
+            };
+            let n_ns = eq_lo.len();
+
+            let accum = |acc: &mut [EF], e: &SparseValue<EF>, gp: EF| {
+                let sel_lo = if s_hi > 0 { e.selector >> s_hi } else { e.selector };
+                let base = sel_lo * n_ns;
+                for (b, &eq_v) in eq_lo.iter().enumerate() {
+                    let coeff = gp * eq_v;
+                    for (a, &fv) in acc.iter_mut().zip(&f[(base + b) * n_hi..][..n_hi]) {
+                        *a += coeff * fv;
+                    }
+                }
+            };
+
+            if s_hi == 0 {
+                // All selector bits in lo-half → shared eq_svo → merge
+                let eq_svo = eval_eq(&smt.point[lo_ns..]);
+                let mut acc = EF::zero_vec(n_hi);
+                let mut vals = Vec::with_capacity(smt.values.len());
+                for (i, e) in smt.values.iter().enumerate() {
+                    accum(&mut acc, e, gamma_pows[vi + i]);
+                    vals.push((gamma_pows[vi + i], e.selector));
+                }
+                vec![(eq_svo, acc, (eq_lo, vals))]
+            } else {
+                // Selector bits spill into hi-half → per-value entries
+                smt.values
+                    .iter()
+                    .enumerate()
+                    .map(|(i, e)| {
+                        let gp = gamma_pows[vi + i];
+                        let sel_lo = e.selector >> s_hi;
+                        let sel_hi = e.selector & ((1 << s_hi) - 1);
+                        let mut eq_svo = EF::zero_vec(n_hi);
+                        compute_sparse_eval_eq(sel_hi, &smt.point[lo_ns..], &mut eq_svo, EF::ONE);
+                        let mut acc = EF::zero_vec(n_hi);
+                        accum(&mut acc, e, gp);
+                        (eq_svo, acc, (eq_lo.clone(), vec![(gp, sel_lo)]))
+                    })
+                    .collect()
+            }
+        })
+        .collect();
+
+    let mut eq_svos = Vec::new();
+    let mut accumulators = Vec::new();
+    let mut weight_info = Vec::new();
+    for group in groups {
+        for (eq, acc, wi) in group {
+            eq_svos.push(eq);
+            accumulators.push(acc);
+            weight_info.push(wi);
+        }
+    }
+    (eq_svos, accumulators, weight_info)
 }
 
 pub fn verify_reduction_many_sparse_claims_to_single_dense(
     verifier_state: &mut impl FSVerifier<EF>,
     statements: &[SparseStatement<EF>],
 ) -> Result<Evaluation<EF>, ProofError> {
-    let n_vars = statements[0].total_num_variables;
-    assert!(statements.iter().all(|s| s.total_num_variables == n_vars));
+    let l = statements[0].total_num_variables;
+    assert!(statements.iter().all(|s| s.total_num_variables == l));
 
     let gamma: EF = verifier_state.sample();
-
-    let mut claimed_sum = EF::ZERO;
-    let mut gamma_pow = EF::ONE;
-    for smt in statements {
-        for e in &smt.values {
-            claimed_sum += gamma_pow * e.value;
-            gamma_pow *= gamma;
-        }
-    }
-
+    let y_alpha = claimed_sum(statements, gamma);
     let Evaluation {
-        point: challenges,
-        value: final_claimed_sum,
-    } = sumcheck_verify(verifier_state, n_vars, 2, claimed_sum, None)?;
-
-    let w_eval = eval_combined_sparse_weights(statements, gamma, &challenges);
-    let p_eval = final_claimed_sum / w_eval;
-
-    Ok(Evaluation::new(challenges, p_eval))
+        point: r,
+        value: final_sum,
+    } = sumcheck_verify(verifier_state, l, 2, y_alpha, None)?;
+    let point = r.reversed();
+    let w_eval = eval_weight_at_point(statements, gamma, &point);
+    Ok(Evaluation::new(point, final_sum / w_eval))
 }
 
-fn eval_combined_sparse_weights(statements: &[SparseStatement<EF>], gamma: EF, point: &MultilinearPoint<EF>) -> EF {
-    let mut value = EF::ZERO;
-    let mut gamma_pow = EF::ONE;
+// ---------------------------------------------------------------------------
 
+fn claimed_sum(statements: &[SparseStatement<EF>], gamma: EF) -> EF {
+    let mut sum = EF::ZERO;
+    let mut gp = EF::ONE;
+    for smt in statements {
+        for e in &smt.values {
+            sum += gp * e.value;
+            gp *= gamma;
+        }
+    }
+    sum
+}
+
+#[inline]
+fn fold_lsb(v: &mut Vec<EF>, r: EF) {
+    let half = v.len() / 2;
+    for i in 0..half {
+        v[i] = v[2 * i] + r * (v[2 * i + 1] - v[2 * i]);
+    }
+    v.truncate(half);
+}
+
+fn eval_weight_at_point(statements: &[SparseStatement<EF>], gamma: EF, point: &MultilinearPoint<EF>) -> EF {
+    let mut value = EF::ZERO;
+    let mut gp = EF::ONE;
     for smt in statements {
         let inner_eq = smt.point.eq_poly_outside(&MultilinearPoint(
             point[point.len() - smt.inner_num_variables()..].to_vec(),
         ));
-        let sel_n_vars = smt.selector_num_variables();
+        let s = smt.selector_num_variables();
         for e in &smt.values {
-            let selector_eq: EF = (0..sel_n_vars)
+            let sel_eq: EF = (0..s)
                 .map(|j| {
-                    if e.selector & (1 << (sel_n_vars - 1 - j)) == 0 {
+                    if e.selector & (1 << (s - 1 - j)) == 0 {
                         EF::ONE - point[j]
                     } else {
                         point[j]
                     }
                 })
                 .product();
-            value += gamma_pow * selector_eq * inner_eq;
-            gamma_pow *= gamma;
+            value += gp * sel_eq * inner_eq;
+            gp *= gamma;
         }
     }
-
     value
-}
-
-#[instrument(skip_all, fields(num_constraints = statements.len(), n_vars = statements[0].total_num_variables))]
-pub fn combine_sparse_statements<EF>(statements: &[SparseStatement<EF>], gamma: EF) -> (Vec<EFPacking<EF>>, EF)
-where
-    EF: ExtensionField<PF<EF>>,
-{
-    let num_variables = statements[0].total_num_variables;
-    assert!(statements.iter().all(|e| e.total_num_variables == num_variables));
-
-    let mut combined_weights = EFPacking::<EF>::zero_vec(1 << (num_variables - packing_log_width::<EF>()));
-
-    let mut combined_sum = EF::ZERO;
-    let mut gamma_pow = EF::ONE;
-
-    for smt in statements {
-        if smt.values.len() == 1 || smt.inner_num_variables() < packing_log_width::<EF>() {
-            for evaluation in &smt.values {
-                compute_sparse_eval_eq_packed::<EF>(evaluation.selector, &smt.point, &mut combined_weights, gamma_pow);
-                combined_sum += evaluation.value * gamma_pow;
-                gamma_pow *= gamma;
-            }
-        } else {
-            let poly_eq = eval_eq_packed(&smt.point);
-            let shift = smt.inner_num_variables() - packing_log_width::<EF>();
-            let mut indexed_smt_values = smt.values.iter().enumerate().collect::<Vec<_>>();
-            indexed_smt_values.sort_by_key(|(_, e)| e.selector);
-            indexed_smt_values.dedup_by_key(|(_, e)| e.selector);
-            assert_eq!(
-                indexed_smt_values.len(),
-                smt.values.len(),
-                "Duplicate selectors in sparse statement"
-            );
-            let mut chunks_mut = split_at_mut_many(
-                &mut combined_weights,
-                &indexed_smt_values
-                    .iter()
-                    .map(|(_, e)| e.selector << shift)
-                    .collect::<Vec<_>>(),
-            );
-            chunks_mut.remove(0);
-            let mut next_gamma_powers = vec![gamma_pow];
-            for _ in 1..indexed_smt_values.len() {
-                next_gamma_powers.push(*next_gamma_powers.last().unwrap() * gamma);
-            }
-            for (e, &scalar) in smt.values.iter().zip(&next_gamma_powers) {
-                combined_sum += e.value * scalar;
-            }
-            chunks_mut
-                .into_par_iter()
-                .zip(&indexed_smt_values)
-                .for_each(|(out_buff, &(origin_index, _))| {
-                    out_buff[..1 << shift]
-                        .par_iter_mut()
-                        .zip(&poly_eq)
-                        .for_each(|(out_elem, &poly_eq_elem)| {
-                            *out_elem += poly_eq_elem * next_gamma_powers[origin_index];
-                        });
-                });
-            gamma_pow = *next_gamma_powers.last().unwrap() * gamma;
-        }
-    }
-
-    (combined_weights, combined_sum)
 }

--- a/crates/sub_protocols/src/stacked_pcs.rs
+++ b/crates/sub_protocols/src/stacked_pcs.rs
@@ -9,6 +9,51 @@ use tracing::instrument;
 use utils::VarCount;
 use utils::ansi::Colorize;
 
+#[derive(Clone, Debug)]
+pub struct SparseStatement<EF> {
+    pub total_num_variables: usize,
+    pub point: MultilinearPoint<EF>,
+    pub values: Vec<SparseValue<EF>>,
+}
+
+impl<EF> SparseStatement<EF> {
+    pub fn new(total_num_variables: usize, point: MultilinearPoint<EF>, values: Vec<SparseValue<EF>>) -> Self {
+        Self {
+            total_num_variables,
+            point,
+            values,
+        }
+    }
+
+    pub fn unique_value(total_num_variables: usize, index: usize, value: EF) -> Self {
+        Self {
+            total_num_variables,
+            point: MultilinearPoint(vec![]),
+            values: vec![SparseValue { selector: index, value }],
+        }
+    }
+
+    pub fn selector_num_variables(&self) -> usize {
+        self.total_num_variables - self.inner_num_variables()
+    }
+
+    pub fn inner_num_variables(&self) -> usize {
+        self.point.len()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SparseValue<EF> {
+    pub selector: usize,
+    pub value: EF,
+}
+
+impl<EF> SparseValue<EF> {
+    pub fn new(selector: usize, value: EF) -> Self {
+        Self { selector, value }
+    }
+}
+
 /*
 Stacking of various (multilinear) polynomials into a single -big- (multilinear) polynomial, which is committed via WHIR.
 [------------------------------ Memory ------------------------------]
@@ -192,7 +237,7 @@ pub fn min_stacked_n_vars(log_bytecode: usize) -> usize {
     compute_stacked_n_vars(MIN_LOG_MEMORY_SIZE, log_bytecode, &min_tables_log_heights)
 }
 
-pub fn total_whir_statements() -> usize {
+pub fn total_sparse_statements() -> usize {
     6 // memory + memory_acc + public_memory + bytecode_acc + pc_start + pc_end
      + ALL_TABLES
         .iter()

--- a/crates/whir/src/lib.rs
+++ b/crates/whir/src/lib.rs
@@ -2,7 +2,6 @@
 
 mod commit;
 pub use commit::*;
-use poly::*;
 
 mod open;
 pub use open::*;
@@ -26,56 +25,3 @@ pub(crate) use utils::*;
 
 mod matrix;
 pub(crate) use matrix::*;
-
-#[derive(Clone, Debug)]
-pub struct SparseStatement<EF> {
-    pub total_num_variables: usize,
-    pub point: MultilinearPoint<EF>,
-    pub values: Vec<SparseValue<EF>>,
-}
-
-impl<EF> SparseStatement<EF> {
-    pub fn new(total_num_variables: usize, point: MultilinearPoint<EF>, values: Vec<SparseValue<EF>>) -> Self {
-        Self {
-            total_num_variables,
-            point,
-            values,
-        }
-    }
-
-    pub fn unique_value(total_num_variables: usize, index: usize, value: EF) -> Self {
-        Self {
-            total_num_variables,
-            point: MultilinearPoint(vec![]),
-            values: vec![SparseValue { selector: index, value }],
-        }
-    }
-
-    pub fn dense(point: MultilinearPoint<EF>, value: EF) -> Self {
-        Self {
-            total_num_variables: point.len(),
-            point,
-            values: vec![SparseValue { selector: 0, value }],
-        }
-    }
-
-    pub fn selector_num_variables(&self) -> usize {
-        self.total_num_variables - self.inner_num_variables()
-    }
-
-    pub fn inner_num_variables(&self) -> usize {
-        self.point.len()
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct SparseValue<EF> {
-    pub selector: usize,
-    pub value: EF,
-}
-
-impl<EF> SparseValue<EF> {
-    pub fn new(selector: usize, value: EF) -> Self {
-        Self { selector, value }
-    }
-}

--- a/crates/whir/src/open.rs
+++ b/crates/whir/src/open.rs
@@ -2,10 +2,11 @@
 
 use ::utils::log2_strict_usize;
 use fiat_shamir::{FSProver, MerklePath, ProofResult};
-use field::PrimeCharacteristicRing;
-use field::{ExtensionField, Field, TwoAdicField};
+use field::{ExtensionField, Field, PackedFieldExtension, PackedValue, TwoAdicField};
+use field::{PrimeCharacteristicRing, dot_product};
 use poly::*;
-use sumcheck::{ProductComputation, run_product_sumcheck, sumcheck_prove_many_rounds};
+use rayon::prelude::*;
+use sumcheck::{ProductComputation, sumcheck_prove_many_rounds};
 use tracing::{info_span, instrument};
 
 use crate::{config::WhirConfig, *};
@@ -55,17 +56,13 @@ where
         let folded_evaluations = &round_state.sumcheck_prover.evals;
         let num_variables = self.num_variables - self.folding_factor.total_number(round_index);
 
-        // Base case: final round reached
         if round_index == self.n_rounds() {
             return self.final_round(round_index, prover_state, round_state);
         }
 
         let round_params = &self.round_parameters[round_index];
-
-        // Compute the folding factors for later use
         let folding_factor_next = self.folding_factor.at_round(round_index + 1);
 
-        // Compute polynomial evaluations and build Merkle tree
         let domain_reduction = 1 << self.rs_reduction_factor(round_index);
         let new_domain_size = round_state.domain_size / domain_reduction;
         let inv_rate = new_domain_size >> num_variables;
@@ -80,10 +77,8 @@ where
 
         let full = 1 << folding_factor_next;
         let (prover_data, root) = MerkleData::build(folded_matrix, full, full);
-
         prover_state.add_base_scalars(&root);
 
-        // Handle OOD (Out-Of-Domain) samples
         let (ood_points, ood_answers) =
             sample_ood_points::<EF, _>(prover_state, round_params.ood_samples, num_variables, |point| {
                 info_span!("ood evaluation").in_scope(|| folded_evaluations.evaluate(point))
@@ -123,7 +118,6 @@ where
                     .product::<EF>();
                 stir_evaluations.push(eval_a * last_fold_rand_a + eval_b * last_fold_rand_b);
             }
-
             stir_evaluations
         } else {
             open_merkle_tree_at_challenges(&round_state.merkle_prover_data, prover_state, &stir_challenges_indexes)
@@ -132,7 +126,6 @@ where
                 .collect()
         };
 
-        // Randomness for combination
         let combination_randomness_gen: EF = prover_state.sample();
         let ood_combination_randomness: Vec<_> = combination_randomness_gen.powers().collect_n(ood_challenges.len());
         round_state
@@ -159,7 +152,6 @@ where
 
         round_state.randomness_vec.extend_from_slice(&next_folding_randomness.0);
 
-        // Update round state
         round_state.domain_size = new_domain_size;
         round_state.next_domain_gen =
             PF::<EF>::two_adic_generator(log2_strict_usize(new_domain_size) - folding_factor_next);
@@ -175,7 +167,6 @@ where
         prover_state: &mut impl FSProver<EF>,
         round_state: &mut RoundState<EF>,
     ) -> ProofResult<()> {
-        // Convert evaluations to coefficient form and send to the verifier.
         let mut coeffs = match &round_state.sumcheck_prover.evals {
             MleOwned::Extension(evals) => evals.clone(),
             MleOwned::ExtensionPacked(evals) => unpack_extension::<EF>(evals),
@@ -186,9 +177,7 @@ where
 
         prover_state.pow_grinding(self.final_query_pow_bits);
 
-        // Final verifier queries and answers. The indices are over the folded domain.
         let final_challenge_indexes = get_challenge_stir_queries(
-            // The size of the original domain before folding
             round_state.domain_size >> self.folding_factor.at_round(round_index),
             self.final_queries,
             prover_state,
@@ -198,7 +187,6 @@ where
         let mut ext_paths = Vec::new();
         for challenge in final_challenge_indexes {
             let (answer, sibling_hashes) = round_state.merkle_prover_data.open(challenge);
-
             match answer {
                 MleOwned::Base(leaf) => {
                     base_paths.push(MerklePath {
@@ -224,13 +212,11 @@ where
             prover_state.hint_merkle_paths_extension(ext_paths);
         }
 
-        // Run final sumcheck if required
         if self.final_sumcheck_rounds > 0 {
             let final_folding_randomness =
                 round_state
                     .sumcheck_prover
                     .run_sumcheck_many_rounds(None, prover_state, self.final_sumcheck_rounds, 0);
-
             round_state.randomness_vec.extend(final_folding_randomness.0);
         }
 
@@ -252,7 +238,6 @@ where
             round_params.num_queries,
             prover_state,
         );
-
         let domain_scaled_gen = round_state.next_domain_gen;
         let ood_challenges = ood_points
             .iter()
@@ -262,7 +247,6 @@ where
             .iter()
             .map(|i| MultilinearPoint::expand_from_univariate(domain_scaled_gen.exp_u64(*i as u64), num_variables))
             .collect();
-
         Ok((ood_challenges, stir_challenges, stir_challenges_indexes))
     }
 }
@@ -278,7 +262,6 @@ fn open_merkle_tree_at_challenges<EF: ExtensionField<PF<EF>>>(
 
     for &challenge in stir_challenges_indexes {
         let (answer, sibling_hashes) = merkle_tree.open(challenge);
-
         match &answer {
             MleOwned::Base(leaf) => {
                 base_paths.push(MerklePath {
@@ -311,11 +294,8 @@ fn open_merkle_tree_at_challenges<EF: ExtensionField<PF<EF>>>(
 
 #[derive(Debug, Clone)]
 pub struct SumcheckSingle<EF: ExtensionField<PF<EF>>> {
-    /// Evaluations of the polynomial `p(X)`.
     pub(crate) evals: MleOwned<EF>,
-    /// Evaluations of the equality polynomial used for enforcing constraints.
     pub(crate) weights: MleOwned<EF>,
-    /// Accumulated sum incorporating equality constraints.
     pub(crate) sum: EF,
 }
 
@@ -332,14 +312,12 @@ where
     ) {
         assert_eq!(combination_randomness.len(), points.len());
         assert_eq!(evaluations.len(), points.len());
-
         points
             .iter()
             .zip(combination_randomness.iter())
             .for_each(|(point, &rand)| {
                 compute_eval_eq_packed::<_, true>(point, self.weights.as_extension_packed_mut().unwrap(), rand);
             });
-
         self.sum += combination_randomness
             .iter()
             .zip(evaluations.iter())
@@ -356,17 +334,12 @@ where
     ) {
         assert_eq!(combination_randomness.len(), points.len());
         assert_eq!(evaluations.len(), points.len());
-
-        // Parallel update of weight buffer
-
         points
             .iter()
             .zip(combination_randomness.iter())
             .for_each(|(point, &rand)| {
                 compute_eval_eq_base_packed::<_, _, true>(point, self.weights.as_extension_packed_mut().unwrap(), rand);
             });
-
-        // Accumulate the weighted sum (cheap, done sequentially)
         self.sum += combination_randomness
             .iter()
             .zip(evaluations.iter())
@@ -394,13 +367,13 @@ where
             false,
             pow_bits,
         );
-
         self.sum = new_sum;
         [self.evals, self.weights] = folds.split().try_into().unwrap();
-
         challenges
     }
 
+    /// SVO + split-eq optimized initial sumcheck with SIMD packing.
+    #[instrument(name = "svo_initial_sumcheck", skip_all)]
     pub(crate) fn run_initial_sumcheck_rounds(
         evals: &MleRef<'_, EF>,
         claims: &[Evaluation<EF>],
@@ -411,29 +384,115 @@ where
     ) -> (Self, MultilinearPoint<EF>) {
         assert_ne!(folding_factor, 0);
 
-        let (weights, sum) = combine_claims(claims, combination_randomness);
+        let n_vars = claims[0].point.len();
+        let n_claims = claims.len();
+        let half = n_vars / 2;
+        let n_svo = 1usize << half;
+        let n_hi = 1usize << (n_vars - half);
 
-        let mut evals = evals.pack();
-        let mut weights = Mle::Owned(MleOwned::ExtensionPacked(weights));
-        let (challengess, new_sum, new_evals, new_weights) = run_product_sumcheck(
-            &evals.by_ref(),
-            &weights.by_ref(),
-            prover_state,
-            sum,
-            folding_factor,
-            pow_bits,
-        );
+        let mut gamma_pows = vec![EF::ONE; n_claims];
+        for i in 1..n_claims {
+            gamma_pows[i] = gamma_pows[i - 1] * combination_randomness;
+        }
+        let sum: EF = claims.iter().zip(&gamma_pows).map(|(c, &gp)| gp * c.value).sum();
 
-        evals = new_evals.into();
-        weights = new_weights.into();
+        // Packed eq_hi for SIMD accumulator and weight combination
+        let eq_his_packed: Vec<Vec<EFPacking<EF>>> = claims.iter().map(|c| eval_eq_packed(&c.point[half..])).collect();
+        let mut eq_svos: Vec<Vec<EF>> = claims
+            .iter()
+            .enumerate()
+            .map(|(i, c)| eval_eq_scaled(&c.point[..half], gamma_pows[i]))
+            .collect();
+
+        // SIMD-packed accumulator precomputation: A_i[u] = sum_{b_hi} eq_hi_i[b_hi] * f[u * n_hi + b_hi]
+        // Parallelize over u (reads f only once), process all claims per u.
+        let f = evals.as_base().unwrap();
+        let per_u: Vec<Vec<EF>> = (0..n_svo)
+            .into_par_iter()
+            .map(|u| {
+                let f_packed = PFPacking::<EF>::pack_slice(&f[u * n_hi..][..n_hi]);
+                (0..n_claims)
+                    .map(|ci| {
+                        let s: EFPacking<EF> = dot_product(eq_his_packed[ci].iter().copied(), f_packed.iter().copied());
+                        EFPacking::<EF>::to_ext_iter([s]).sum()
+                    })
+                    .collect()
+            })
+            .collect();
+        let mut accumulators: Vec<Vec<EF>> = (0..n_claims)
+            .map(|ci| per_u.iter().map(|row| row[ci]).collect())
+            .collect();
+
+        // SVO rounds (folding MSB first)
+        let mut challenges = Vec::with_capacity(folding_factor);
+        let mut current_sum = sum;
+        let mut current_n_u = n_svo;
+
+        for _round in 0..folding_factor {
+            let half_n_u = current_n_u / 2;
+            let mut c0 = EF::ZERO;
+            let mut c2 = EF::ZERO;
+
+            for i in 0..n_claims {
+                let acc = &accumulators[i];
+                let eq = &eq_svos[i];
+                for u in 0..half_n_u {
+                    c0 += eq[u] * acc[u];
+                    c2 += (eq[u + half_n_u] - eq[u]) * (acc[u + half_n_u] - acc[u]);
+                }
+            }
+
+            let c1 = current_sum - c0 - c0 - c2;
+            let poly = DensePolynomial::new(vec![c0, c1, c2]);
+            prover_state.add_sumcheck_polynomial(&poly.coeffs, None);
+            prover_state.pow_grinding(pow_bits);
+            let challenge: EF = prover_state.sample();
+            challenges.push(challenge);
+            current_sum = poly.evaluate(challenge);
+
+            current_n_u = half_n_u;
+            for i in 0..n_claims {
+                fold_msb_in_place(&mut accumulators[i], current_n_u, challenge);
+                fold_msb_in_place(&mut eq_svos[i], current_n_u, challenge);
+            }
+        }
+
+        // SIMD-packed multi-fold: iterate eq outer, packed saxpy inner.
+        let eq_at_challenges = eval_eq(&challenges);
+        let n_svo_orig = 1usize << folding_factor;
+        let n_rest = 1usize << (n_vars - folding_factor);
+        let n_rest_packed = n_rest >> packing_log_width::<EF>();
+        let mut out_packed = EFPacking::<EF>::zero_vec(n_rest_packed);
+        for u in 0..n_svo_orig {
+            let coeff = EFPacking::<EF>::from(eq_at_challenges[u]);
+            let f_row_packed = PFPacking::<EF>::pack_slice(&f[u * n_rest..][..n_rest]);
+            out_packed
+                .par_iter_mut()
+                .zip(f_row_packed.par_iter())
+                .for_each(|(dest, &fv)| *dest += coeff * fv);
+        }
+
+        // SIMD-packed weight combination
+        let n_u_rem = 1usize << (half - folding_factor);
+        let n_hi_packed = n_hi >> packing_log_width::<EF>();
+        let mut w_packed = EFPacking::<EF>::zero_vec(n_rest_packed);
+        for i in 0..n_claims {
+            for u_rem in 0..n_u_rem {
+                let scale = eq_svos[i][u_rem]; // already includes gamma
+                let dst = &mut w_packed[u_rem * n_hi_packed..][..n_hi_packed];
+                for (d, &eq_v) in dst.iter_mut().zip(&eq_his_packed[i]) {
+                    *d += eq_v * scale;
+                }
+            }
+        }
 
         let sumcheck = Self {
-            evals: evals.as_owned().unwrap(),
-            weights: weights.as_owned().unwrap(),
-            sum: new_sum,
+            evals: MleOwned::ExtensionPacked(out_packed),
+            weights: MleOwned::ExtensionPacked(w_packed),
+            sum: current_sum,
         };
 
-        (sumcheck, challengess)
+        (sumcheck, MultilinearPoint(challenges))
     }
 }
 
@@ -474,7 +533,6 @@ where
                 )
             })
             .collect();
-
         claims.push(dense_claim);
 
         let combination_randomness_gen: EF = prover_state.sample();
@@ -505,24 +563,9 @@ where
     }
 }
 
-#[instrument(skip_all, fields(n_claims = claims.len(), n_vars = claims[0].point.len()))]
-fn combine_claims<EF>(claims: &[Evaluation<EF>], gamma: EF) -> (Vec<EFPacking<EF>>, EF)
-where
-    EF: ExtensionField<PF<EF>>,
-{
-    let num_variables = claims[0].point.len();
-    assert!(claims.iter().all(|c| c.point.len() == num_variables));
-
-    let mut combined_weights = EFPacking::<EF>::zero_vec(1 << (num_variables - packing_log_width::<EF>()));
-
-    let mut combined_sum = EF::ZERO;
-    let mut gamma_pow = EF::ONE;
-
-    for claim in claims {
-        compute_sparse_eval_eq_packed::<EF>(0, &claim.point, &mut combined_weights, gamma_pow);
-        combined_sum += claim.value * gamma_pow;
-        gamma_pow *= gamma;
+fn fold_msb_in_place<EF: Field>(v: &mut Vec<EF>, half: usize, r: EF) {
+    for i in 0..half {
+        v[i] = v[i] + r * (v[i + half] - v[i]);
     }
-
-    (combined_weights, combined_sum)
+    v.truncate(half);
 }

--- a/crates/whir/src/open.rs
+++ b/crates/whir/src/open.rs
@@ -5,7 +5,6 @@ use fiat_shamir::{FSProver, MerklePath, ProofResult};
 use field::PrimeCharacteristicRing;
 use field::{ExtensionField, Field, TwoAdicField};
 use poly::*;
-use rayon::prelude::*;
 use sumcheck::{ProductComputation, run_product_sumcheck, sumcheck_prove_many_rounds};
 use tracing::{info_span, instrument};
 
@@ -20,14 +19,6 @@ where
         self.num_variables == self.folding_factor.total_number(self.n_rounds()) + self.final_sumcheck_rounds
     }
 
-    fn validate_statement(&self, statement: &[SparseStatement<EF>]) {
-        statement.iter().for_each(|e| {
-            assert_eq!(e.total_num_variables, self.num_variables);
-            assert!(!e.values.is_empty());
-            assert!(e.values.iter().all(|v| v.selector < 1 << e.selector_num_variables()));
-        });
-    }
-
     fn validate_witness(&self, witness: &Witness<EF>, polynomial: &MleRef<'_, EF>) -> bool {
         assert_eq!(witness.ood_points.len(), witness.ood_answers.len());
         polynomial.n_vars() == self.num_variables
@@ -37,13 +28,13 @@ where
     pub fn prove(
         &self,
         prover_state: &mut impl FSProver<EF>,
-        statement: Vec<SparseStatement<EF>>,
+        statement: Evaluation<EF>,
         witness: Witness<EF>,
         polynomial: &MleRef<'_, EF>,
     ) -> MultilinearPoint<EF> {
         assert!(self.validate_parameters());
         assert!(self.validate_witness(&witness, polynomial));
-        self.validate_statement(&statement);
+        assert_eq!(statement.point.len(), self.num_variables);
 
         let mut round_state =
             RoundState::initialize_first_round_state(self, prover_state, statement, witness, polynomial).unwrap();
@@ -412,7 +403,7 @@ where
 
     pub(crate) fn run_initial_sumcheck_rounds(
         evals: &MleRef<'_, EF>,
-        statement: &[SparseStatement<EF>],
+        claims: &[Evaluation<EF>],
         combination_randomness: EF,
         prover_state: &mut impl FSProver<EF>,
         folding_factor: usize,
@@ -420,7 +411,7 @@ where
     ) -> (Self, MultilinearPoint<EF>) {
         assert_ne!(folding_factor, 0);
 
-        let (weights, sum) = combine_statement::<EF>(statement, combination_randomness);
+        let (weights, sum) = combine_claims(claims, combination_randomness);
 
         let mut evals = evals.pack();
         let mut weights = Mle::Owned(MleOwned::ExtensionPacked(weights));
@@ -468,29 +459,29 @@ where
     pub(crate) fn initialize_first_round_state(
         prover: &WhirConfig<EF>,
         prover_state: &mut impl FSProver<EF>,
-        mut statement: Vec<SparseStatement<EF>>,
+        dense_claim: Evaluation<EF>,
         witness: Witness<EF>,
         polynomial: &MleRef<'_, EF>,
     ) -> ProofResult<Self> {
-        let ood_statements = witness
+        let mut claims: Vec<Evaluation<EF>> = witness
             .ood_points
             .into_iter()
             .zip(witness.ood_answers)
-            .map(|(point, evaluation)| {
-                SparseStatement::dense(
+            .map(|(point, value)| {
+                Evaluation::new(
                     MultilinearPoint::expand_from_univariate(point, prover.num_variables),
-                    evaluation,
+                    value,
                 )
             })
-            .collect::<Vec<_>>();
+            .collect();
 
-        statement.splice(0..0, ood_statements);
+        claims.push(dense_claim);
 
         let combination_randomness_gen: EF = prover_state.sample();
 
         let (sumcheck_prover, folding_randomness) = SumcheckSingle::run_initial_sumcheck_rounds(
             polynomial,
-            &statement,
+            &claims,
             combination_randomness_gen,
             prover_state,
             prover.folding_factor.at_round(0),
@@ -514,65 +505,23 @@ where
     }
 }
 
-#[instrument(skip_all, fields(num_constraints = statements.len(), n_vars = statements[0].total_num_variables))]
-fn combine_statement<EF>(statements: &[SparseStatement<EF>], gamma: EF) -> (Vec<EFPacking<EF>>, EF)
+#[instrument(skip_all, fields(n_claims = claims.len(), n_vars = claims[0].point.len()))]
+fn combine_claims<EF>(claims: &[Evaluation<EF>], gamma: EF) -> (Vec<EFPacking<EF>>, EF)
 where
     EF: ExtensionField<PF<EF>>,
 {
-    let num_variables = statements[0].total_num_variables;
-    assert!(statements.iter().all(|e| e.total_num_variables == num_variables));
+    let num_variables = claims[0].point.len();
+    assert!(claims.iter().all(|c| c.point.len() == num_variables));
 
     let mut combined_weights = EFPacking::<EF>::zero_vec(1 << (num_variables - packing_log_width::<EF>()));
 
     let mut combined_sum = EF::ZERO;
     let mut gamma_pow = EF::ONE;
 
-    for smt in statements {
-        if smt.values.len() == 1 || smt.inner_num_variables() < packing_log_width::<EF>() {
-            for evaluation in &smt.values {
-                compute_sparse_eval_eq_packed::<EF>(evaluation.selector, &smt.point, &mut combined_weights, gamma_pow);
-                combined_sum += evaluation.value * gamma_pow;
-                gamma_pow *= gamma;
-            }
-        } else {
-            let poly_eq = eval_eq_packed(&smt.point);
-            let shift = smt.inner_num_variables() - packing_log_width::<EF>();
-            let mut indexed_smt_values = smt.values.iter().enumerate().collect::<Vec<_>>();
-            indexed_smt_values.sort_by_key(|(_, e)| e.selector);
-            indexed_smt_values.dedup_by_key(|(_, e)| e.selector);
-            assert_eq!(
-                indexed_smt_values.len(),
-                smt.values.len(),
-                "Duplicate selectors in sparse statement"
-            );
-            let mut chunks_mut = split_at_mut_many(
-                &mut combined_weights,
-                &indexed_smt_values
-                    .iter()
-                    .map(|(_, e)| e.selector << shift)
-                    .collect::<Vec<_>>(),
-            );
-            chunks_mut.remove(0);
-            let mut next_gamma_powers = vec![gamma_pow];
-            for _ in 1..indexed_smt_values.len() {
-                next_gamma_powers.push(*next_gamma_powers.last().unwrap() * gamma);
-            }
-            for (e, &scalar) in smt.values.iter().zip(&next_gamma_powers) {
-                combined_sum += e.value * scalar;
-            }
-            chunks_mut
-                .into_par_iter()
-                .zip(&indexed_smt_values)
-                .for_each(|(out_buff, &(origin_index, _))| {
-                    out_buff[..1 << shift]
-                        .par_iter_mut()
-                        .zip(&poly_eq)
-                        .for_each(|(out_elem, &poly_eq_elem)| {
-                            *out_elem += poly_eq_elem * next_gamma_powers[origin_index];
-                        });
-                });
-            gamma_pow = *next_gamma_powers.last().unwrap() * gamma;
-        }
+    for claim in claims {
+        compute_sparse_eval_eq_packed::<EF>(0, &claim.point, &mut combined_weights, gamma_pow);
+        combined_sum += claim.value * gamma_pow;
+        gamma_pow *= gamma;
     }
 
     (combined_weights, combined_sum)

--- a/crates/whir/src/verify.rs
+++ b/crates/whir/src/verify.rs
@@ -45,14 +45,14 @@ impl<F: Field, EF: ExtensionField<F>> ParsedCommitment<F, EF> {
         })
     }
 
-    pub fn oods_constraints(&self) -> Vec<SparseStatement<EF>> {
+    fn ood_evaluations(&self) -> Vec<Evaluation<EF>> {
         self.ood_points
             .iter()
             .zip(&self.ood_answers)
-            .map(|(&point, &eval)| {
-                SparseStatement::dense(
+            .map(|(&point, &value)| {
+                Evaluation::new(
                     MultilinearPoint::expand_from_univariate(point, self.num_variables),
-                    eval,
+                    value,
                 )
             })
             .collect()
@@ -84,29 +84,22 @@ where
         &self,
         verifier_state: &mut impl FSVerifier<EF>,
         parsed_commitment: &ParsedCommitment<F, EF>,
-        statement: Vec<SparseStatement<EF>>,
+        dense_claim: Evaluation<EF>,
     ) -> ProofResult<MultilinearPoint<EF>>
     where
         F: TwoAdicField + ExtensionField<PF<EF>>,
         EF: ExtensionField<F>,
     {
-        statement
-            .iter()
-            .for_each(|c| assert_eq!(c.total_num_variables, parsed_commitment.num_variables));
+        assert_eq!(dense_claim.point.len(), parsed_commitment.num_variables);
 
-        // During the rounds we collect constraints, combination randomness, folding randomness
-        // and we update the claimed sum of constraint evaluation.
-        let mut round_constraints = Vec::new();
+        let mut round_constraints: Vec<(Vec<EF>, Vec<Evaluation<EF>>)> = Vec::new();
         let mut round_folding_randomness = Vec::new();
         let mut claimed_sum = EF::ZERO;
         let mut prev_commitment = parsed_commitment.clone();
 
-        // Combine OODS and statement constraints to claimed_sum
-        let constraints: Vec<_> = prev_commitment
-            .oods_constraints()
-            .into_iter()
-            .chain(statement)
-            .collect();
+        // Combine OODs and dense claim
+        let mut constraints = prev_commitment.ood_evaluations();
+        constraints.push(dense_claim);
         let combination_randomness = self.combine_constraints(verifier_state, &mut claimed_sum, &constraints)?;
         round_constraints.push((combination_randomness, constraints));
 
@@ -137,14 +130,11 @@ where
             )?;
 
             // Add out-of-domain and in-domain constraints to claimed_sum
-            let constraints: Vec<SparseStatement<EF>> = new_commitment
-                .oods_constraints()
-                .into_iter()
-                .chain(stir_constraints)
-                .collect();
+            let mut constraints = new_commitment.ood_evaluations();
+            constraints.extend(stir_constraints);
 
             let combination_randomness = self.combine_constraints(verifier_state, &mut claimed_sum, &constraints)?;
-            round_constraints.push((combination_randomness.clone(), constraints));
+            round_constraints.push((combination_randomness, constraints));
 
             let folding_randomness = verify_sumcheck_rounds::<F, EF>(
                 verifier_state,
@@ -204,23 +194,20 @@ where
         Ok(folding_randomness)
     }
 
-    pub(crate) fn combine_constraints(
+    fn combine_constraints(
         &self,
         verifier_state: &mut impl FSVerifier<EF>,
         claimed_sum: &mut EF,
-        constraints: &[SparseStatement<EF>],
+        constraints: &[Evaluation<EF>],
     ) -> ProofResult<Vec<EF>> {
         let combination_randomness_gen: EF = verifier_state.sample();
         let mut combination_randomness = vec![EF::ONE];
-        for smt in constraints {
-            for e in &smt.values {
-                let combination_randomness_pow = *combination_randomness.last().unwrap();
-                *claimed_sum += combination_randomness_pow * e.value;
-                combination_randomness.push(combination_randomness_pow * combination_randomness_gen);
-            }
+        for eval in constraints {
+            let combination_randomness_pow = *combination_randomness.last().unwrap();
+            *claimed_sum += combination_randomness_pow * eval.value;
+            combination_randomness.push(combination_randomness_pow * combination_randomness_gen);
         }
         combination_randomness.pop().unwrap();
-
         Ok(combination_randomness)
     }
 
@@ -231,7 +218,7 @@ where
         commitment: &ParsedCommitment<F, EF>,
         folding_randomness: &MultilinearPoint<EF>,
         round_index: usize,
-    ) -> ProofResult<Vec<SparseStatement<EF>>>
+    ) -> ProofResult<Vec<Evaluation<EF>>>
     where
         F: Field + ExtensionField<PF<EF>>,
         EF: ExtensionField<F>,
@@ -245,9 +232,6 @@ where
             params.num_queries,
             verifier_state,
         );
-
-        // dbg!(&stir_challenges_indexes);
-        // dbg!(verifier_state.challenger().state());
 
         let dimensions = vec![Dimensions {
             height: params.domain_size >> params.folding_factor,
@@ -274,7 +258,7 @@ where
             .map(|&index| params.folded_domain_gen.exp_u64(index as u64))
             .zip(&folds)
             .map(|(point, &value)| {
-                SparseStatement::dense(
+                Evaluation::new(
                     MultilinearPoint::expand_from_univariate(EF::from(point), params.num_variables),
                     value,
                 )
@@ -343,46 +327,27 @@ where
 
     fn eval_constraints_poly(
         &self,
-        constraints: &[(Vec<EF>, Vec<SparseStatement<EF>>)],
+        constraints: &[(Vec<EF>, Vec<Evaluation<EF>>)],
         mut point: MultilinearPoint<EF>,
     ) -> EF {
         let mut value = EF::ZERO;
 
-        for (round, (randomness, constraints)) in constraints.iter().enumerate() {
+        for (round, (randomness, evals)) in constraints.iter().enumerate() {
             if round > 0 {
                 let k = self.folding_factor.at_round(round - 1);
                 point = MultilinearPoint(point[k..].to_vec());
             }
-            let mut i = 0;
-            for smt in constraints {
-                let common_eq = smt.point.eq_poly_outside(&MultilinearPoint(
-                    point[point.len() - smt.inner_num_variables()..].to_vec(),
-                ));
-                for e in &smt.values {
-                    let eval = (0..smt.selector_num_variables())
-                        .map(|j| {
-                            if e.selector & (1 << (smt.selector_num_variables() - 1 - j)) == 0 {
-                                EF::ONE - point[j]
-                            } else {
-                                point[j]
-                            }
-                        })
-                        .product::<EF>()
-                        * common_eq;
-                    value += eval * randomness[i];
-                    i += 1;
-                }
+            for (i, eval) in evals.iter().enumerate() {
+                let eq = eval.point.eq_poly_outside(&point);
+                value += eq * randomness[i];
             }
-            assert_eq!(i, randomness.len());
         }
         value
     }
 }
 
-fn verify_constraint_coeffs<EF: Field>(constraint: &SparseStatement<EF>, coeffs: &[EF]) -> bool {
-    assert_eq!(constraint.selector_num_variables(), 0);
+fn verify_constraint_coeffs<EF: Field>(constraint: &Evaluation<EF>, coeffs: &[EF]) -> bool {
     let alpha = constraint.point[0];
-    // Verify the point is expand_from_univariate(alpha, n): [alpha, alpha^2, alpha^4, ...]
     assert!(
         constraint
             .point
@@ -391,7 +356,7 @@ fn verify_constraint_coeffs<EF: Field>(constraint: &SparseStatement<EF>, coeffs:
             .all(|(&a, &b)| a * a == b)
     );
     let univariate_eval = coeffs.iter().rfold(EF::ZERO, |acc, &c| acc * alpha + c);
-    constraint.values.iter().all(|e| univariate_eval == e.value)
+    univariate_eval == constraint.value
 }
 
 /// The full vector of folding randomness values, in reverse round order.
@@ -407,7 +372,6 @@ where
     F: TwoAdicField,
     EF: ExtensionField<F> + TwoAdicField + ExtensionField<PF<EF>>,
 {
-    // Preallocate vector to hold the randomness values
     let mut randomness = Vec::with_capacity(rounds);
 
     for _ in 0..rounds {

--- a/crates/whir/tests/run_whir.rs
+++ b/crates/whir/tests/run_whir.rs
@@ -56,44 +56,9 @@ fn test_run_whir() {
     let mut rng = StdRng::seed_from_u64(0);
     let polynomial = (0..num_coeffs).map(|_| rng.random::<F>()).collect::<Vec<F>>();
 
-    let random_sparse_point = |rng: &mut StdRng, num_variables: usize| {
-        let selector_len = rng.random_range(0..num_variables / 2);
-        let point = (0..num_variables - selector_len)
-            .map(|_| rng.random())
-            .collect::<Vec<EF>>();
-        (selector_len, MultilinearPoint(point))
-    };
-
-    // Sample `num_points` random multilinear points in the Boolean hypercube
-    let mut points = (0..7)
-        .map(|_| random_sparse_point(&mut rng, num_variables))
-        .collect::<Vec<_>>();
-    points.push((num_variables, MultilinearPoint(vec![])));
-
-    let mut statement = Vec::new();
-
-    // Add constraints for each sampled point (equality constraints)
-    for (selector_len, point) in &points {
-        let num_selectors = rng.random_range(1..5);
-        let mut selectors = vec![];
-        for _ in 0..num_selectors {
-            let selector = rng.random_range(0..(1 << selector_len));
-            if !selectors.contains(&selector) {
-                selectors.push(selector);
-            }
-        }
-        statement.push(SparseStatement::new(
-            num_variables,
-            point.clone(),
-            selectors
-                .iter()
-                .map(|selector| SparseValue {
-                    selector: *selector,
-                    value: polynomial.evaluate_sparse(*selector, point),
-                })
-                .collect(),
-        ));
-    }
+    let eval_point = MultilinearPoint((0..num_variables).map(|_| rng.random::<EF>()).collect());
+    let eval_value = polynomial.evaluate(&eval_point);
+    let statement = Evaluation::new(eval_point, eval_value);
 
     let mut prover_state = ProverState::new(poseidon16.clone());
 

--- a/src/prove_poseidons.rs
+++ b/src/prove_poseidons.rs
@@ -79,7 +79,7 @@ pub fn benchmark_prove_poseidon_16(log_n_rows: usize, tracing: bool) {
 
         whir_config.prove(
             &mut prover_state,
-            vec![SparseStatement::dense(packed_point, packed_eval)],
+            Evaluation::new(packed_point, packed_eval),
             witness,
             &committed_pol.by_ref(),
         );
@@ -111,7 +111,7 @@ pub fn benchmark_prove_poseidon_16(log_n_rows: usize, tracing: bool) {
             .verify(
                 &mut verifier_state,
                 &parsed_commitment,
-                vec![SparseStatement::dense(packed_point, packed_eval)],
+                Evaluation::new(packed_point, packed_eval),
             )
             .unwrap();
     }


### PR DESCRIPTION
An attempt to tackle https://github.com/leanEthereum/leanMultisig/issues/164


For more details, see:
- https://github.com/TomWambsgans/misc/blob/master/pcs_in_2_sumchecks.pdf
- https://github.com/tcoratger/whir-p3/blob/main/src/sumcheck/svo.rs
- https://github.com/kilic/whir/blob/main/crates/whir/src/sumcheck/svo.rs