### PR TITLE
lean_vm: add source-level failure stack traces

### DIFF
--- a/crates/lean_compiler/src/b_compile_intermediate.rs
+++ b/crates/lean_compiler/src/b_compile_intermediate.rs
@@ -502,6 +502,12 @@ fn compile_lines(
                 let new_fp_pos = compiler.stack_pos;
                 compiler.stack_pos += 1;
 
+                instructions.push(IntermediateInstruction::CallSite {
+                    caller: compiler.func_name.clone(),
+                    callee: callee_function_name.clone(),
+                    location: *location,
+                    return_label: return_label.clone(),
+                });
                 instructions.extend(emit_call_frame(
                     callee_function_name,
                     args,

--- a/crates/lean_compiler/src/c_compile_final.rs
+++ b/crates/lean_compiler/src/c_compile_final.rs
@@ -12,6 +12,7 @@ impl IntermediateInstruction {
             | Self::HintWitness { .. }
             | Self::Inverse { .. }
             | Self::LocationReport { .. }
+            | Self::CallSite { .. }
             | Self::DebugAssert { .. }
             | Self::DerefHint { .. }
             | Self::PanicHint { .. }
@@ -53,6 +54,7 @@ pub fn compile_to_low_level_bytecode(
         .ok_or("Missing main function")?;
 
     let mut hints = BTreeMap::new();
+    let mut call_sites_by_return_pc = BTreeMap::new();
     let mut label_to_pc = BTreeMap::new();
 
     let exit_point = intermediate_bytecode
@@ -129,6 +131,7 @@ pub fn compile_to_low_level_bytecode(
             pc_start,
             &mut instructions,
             &mut hints,
+            &mut call_sites_by_return_pc,
             &mut hint_name_to_index,
         );
     }
@@ -180,6 +183,7 @@ pub fn compile_to_low_level_bytecode(
             filepaths,
             source_code,
             pc_to_location,
+            call_sites_by_return_pc,
         },
     ))
 }
@@ -190,6 +194,7 @@ fn compile_block(
     pc_start: CodeAddress,
     low_level_bytecode: &mut Vec<Instruction>,
     hints: &mut BTreeMap<CodeAddress, Vec<Hint>>,
+    call_sites_by_return_pc: &mut BTreeMap<CodeAddress, CallSite>,
     hint_names: &mut BTreeMap<String, usize>,
 ) {
     let try_as_mem_or_constant = |value: &IntermediateValue| {
@@ -354,6 +359,28 @@ fn compile_block(
             IntermediateInstruction::LocationReport { location } => {
                 let hint = Hint::LocationReport { location };
                 hints.entry(pc).or_default().push(hint);
+            }
+            IntermediateInstruction::CallSite {
+                caller,
+                callee,
+                location,
+                return_label,
+            } => {
+                let return_pc = compiler
+                    .label_to_pc
+                    .get(&return_label)
+                    .copied()
+                    .expect("Fatal: unresolved call return label");
+                call_sites_by_return_pc.insert(
+                    return_pc,
+                    CallSite {
+                        caller,
+                        callee,
+                        location,
+                        call_pc: return_pc.saturating_sub(1),
+                        return_pc,
+                    },
+                );
             }
             IntermediateInstruction::DebugAssert {
                 expr,

--- a/crates/lean_compiler/src/ir/instruction.rs
+++ b/crates/lean_compiler/src/ir/instruction.rs
@@ -1,6 +1,8 @@
 use super::value::IntermediateValue;
 use crate::lang::{ConstExpression, MathOperation};
-use lean_vm::{BooleanExpr, CustomHint, HintWitnessDestination, Operation, PrecompileArgs, SourceLocation};
+use lean_vm::{
+    BooleanExpr, CustomHint, FunctionName, HintWitnessDestination, Label, Operation, PrecompileArgs, SourceLocation,
+};
 use std::fmt::{Display, Formatter};
 
 /// Core instruction type for the intermediate representation.
@@ -57,6 +59,13 @@ pub enum IntermediateInstruction {
     // noop, debug purpose only
     LocationReport {
         location: SourceLocation,
+    },
+    // No-op metadata used to reconstruct source-level call stacks.
+    CallSite {
+        caller: FunctionName,
+        callee: FunctionName,
+        location: SourceLocation,
+        return_label: Label,
     },
     DebugAssert {
         expr: BooleanExpr<IntermediateValue>,
@@ -192,6 +201,15 @@ impl Display for IntermediateInstruction {
                 Ok(())
             }
             Self::LocationReport { .. } => Ok(()),
+            Self::CallSite {
+                caller,
+                callee,
+                location,
+                return_label,
+            } => write!(
+                f,
+                "call_site {caller} -> {callee} at {location}, returns to {return_label}"
+            ),
             Self::DebugAssert { expr, .. } => {
                 write!(f, "debug_assert {expr}")
             }

--- a/crates/lean_compiler/src/lib.rs
+++ b/crates/lean_compiler/src/lib.rs
@@ -145,6 +145,23 @@ pub struct CompilationFlags {
     pub replacements: BTreeMap<String, String>,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct CompileAndRunOptions {
+    /// Include VM profiling metadata in the execution summary.
+    pub profiler: bool,
+    /// Print a source-level stack trace to stderr when VM execution fails.
+    pub stack_trace: bool,
+}
+
+impl Default for CompileAndRunOptions {
+    fn default() -> Self {
+        Self {
+            profiler: false,
+            stack_trace: true,
+        }
+    }
+}
+
 pub fn try_compile_program_with_flags(
     input: &ProgramSource,
     flags: CompilationFlags,
@@ -182,7 +199,35 @@ pub fn try_compile_and_run(
     Ok(result.metadata.display())
 }
 
+pub fn try_compile_and_run_with_options(
+    input: &ProgramSource,
+    public_input: &[F; PUBLIC_INPUT_LEN],
+    options: CompileAndRunOptions,
+) -> Result<String, Error> {
+    let bytecode = try_compile_program(input)?;
+    let witness = ExecutionWitness::default();
+    let result = try_execute_bytecode_with_options(
+        &bytecode,
+        public_input,
+        &witness,
+        ExecutionOptions {
+            profiling: options.profiler,
+            stack_trace: options.stack_trace,
+        },
+    )?;
+    Ok(result.metadata.display())
+}
+
 pub fn compile_and_run(input: &ProgramSource, public_input: &[F; PUBLIC_INPUT_LEN], profiler: bool) {
     let summary = try_compile_and_run(input, public_input, profiler).unwrap();
+    println!("{summary}");
+}
+
+pub fn compile_and_run_with_options(
+    input: &ProgramSource,
+    public_input: &[F; PUBLIC_INPUT_LEN],
+    options: CompileAndRunOptions,
+) {
+    let summary = try_compile_and_run_with_options(input, public_input, options).unwrap();
     println!("{summary}");
 }

--- a/crates/lean_compiler/tests/test_compiler.rs
+++ b/crates/lean_compiler/tests/test_compiler.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use std::{process::Command, time::Instant};
 
 use backend::{ArenaVec, BasedVectorSpace, PrimeCharacteristicRing, arena_vec};
 use lean_compiler::*;
@@ -255,6 +255,200 @@ def main():
     return
    "#;
     compile_and_run(&ProgramSource::Raw(program.to_string()), &[F::ZERO; DIGEST_LEN], false);
+}
+
+#[test]
+fn nested_runtime_failure_prints_full_call_stack() {
+    let current_exe = std::env::current_exe().expect("current test executable path");
+    let output = Command::new(current_exe)
+        .arg("--exact")
+        .arg("child_nested_runtime_failure_prints_stack_trace")
+        .arg("--nocapture")
+        .env("LEANVM_STACK_TRACE_CHILD", "1")
+        .output()
+        .expect("run child stack trace test");
+
+    assert!(
+        output.status.success(),
+        "child test failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_stack_frames(&stderr, &["d()", "c()", "b()", "a()", "main()"]);
+    assert!(
+        stderr.contains("pc="),
+        "stack trace should include pc values\nstderr:\n{stderr}",
+    );
+    assert!(
+        stderr.contains(":15"),
+        "stack trace should include the failing source line\nstderr:\n{stderr}",
+    );
+}
+
+#[test]
+fn parallel_runtime_failure_prints_worker_call_stack() {
+    let current_exe = std::env::current_exe().expect("current test executable path");
+    let output = Command::new(current_exe)
+        .arg("--exact")
+        .arg("child_parallel_runtime_failure_prints_stack_trace")
+        .arg("--nocapture")
+        .env("LEANVM_STACK_TRACE_CHILD", "1")
+        .output()
+        .expect("run child parallel stack trace test");
+
+    assert!(
+        output.status.success(),
+        "child test failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_stack_frames(&stderr, &["fail()", "main()"]);
+    assert!(
+        stderr.contains("pc="),
+        "parallel stack trace should include pc values\nstderr:\n{stderr}",
+    );
+}
+
+fn assert_stack_frames(stderr: &str, expected_frames: &[&str]) {
+    let stack = stderr
+        .split("CALL STACK")
+        .nth(1)
+        .unwrap_or_else(|| panic!("stderr should contain a CALL STACK section\nstderr:\n{stderr}"));
+    let frame_lines: Vec<&str> = stack.lines().filter(|line| line.contains("pc=")).collect();
+
+    assert_eq!(
+        frame_lines.len(),
+        expected_frames.len(),
+        "stack trace should contain exactly the expected frames\nframes:\n{}\nstderr:\n{stderr}",
+        frame_lines.join("\n"),
+    );
+    for (line, expected) in frame_lines.iter().zip(expected_frames) {
+        assert!(
+            line.contains(expected),
+            "stack frame should contain {expected}\nframe: {line}\nstderr:\n{stderr}",
+        );
+    }
+}
+
+#[test]
+fn child_nested_runtime_failure_prints_stack_trace() {
+    if std::env::var_os("LEANVM_STACK_TRACE_CHILD").is_none() {
+        return;
+    }
+
+    let program = r#"def main():
+    _ = a()
+    return
+
+def a():
+    return b()
+
+def b():
+    return c()
+
+def c():
+    return d()
+
+def d():
+    debug_assert(0 == 1)
+    return 0
+"#;
+
+    let result = try_compile_and_run_with_options(
+        &ProgramSource::Raw(program.to_string()),
+        &[F::ZERO; DIGEST_LEN],
+        CompileAndRunOptions {
+            profiler: false,
+            stack_trace: true,
+        },
+    );
+
+    assert!(
+        matches!(result, Err(Error::Runtime(_))),
+        "program should fail at VM runtime inside d(), got {result:?}",
+    );
+}
+
+#[test]
+fn child_parallel_runtime_failure_prints_stack_trace() {
+    if std::env::var_os("LEANVM_STACK_TRACE_CHILD").is_none() {
+        return;
+    }
+
+    let program = r#"def main():
+    n = 4
+    for i in parallel_range(0, n):
+        fail(i)
+    return
+
+def fail(i):
+    if i == 2:
+        debug_assert(0 == 1)
+    return
+"#;
+
+    let result = try_compile_and_run_with_options(
+        &ProgramSource::Raw(program.to_string()),
+        &[F::ZERO; DIGEST_LEN],
+        CompileAndRunOptions {
+            profiler: false,
+            stack_trace: true,
+        },
+    );
+
+    assert!(
+        matches!(result, Err(Error::Runtime(_))),
+        "parallel program should fail at VM runtime inside fail(), got {result:?}",
+    );
+}
+
+#[test]
+fn legacy_runtime_failure_respects_stack_trace_env_var() {
+    let current_exe = std::env::current_exe().expect("current test executable path");
+    let output = Command::new(current_exe)
+        .arg("--exact")
+        .arg("child_legacy_runtime_failure_respects_stack_trace_env_var")
+        .arg("--nocapture")
+        .env("LEANVM_STACK_TRACE_CHILD", "1")
+        .env("LEANVM_STACK_TRACE", "0")
+        .output()
+        .expect("run child legacy env-var stack trace test");
+
+    assert!(
+        output.status.success(),
+        "child test failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("CALL STACK"),
+        "LEANVM_STACK_TRACE=0 should disable legacy stack trace printing\nstderr:\n{stderr}",
+    );
+}
+
+#[test]
+fn child_legacy_runtime_failure_respects_stack_trace_env_var() {
+    if std::env::var_os("LEANVM_STACK_TRACE_CHILD").is_none() {
+        return;
+    }
+
+    let program = r#"def main():
+    debug_assert(0 == 1)
+    return
+"#;
+
+    let result = try_compile_and_run(&ProgramSource::Raw(program.to_string()), &[F::ZERO; DIGEST_LEN], false);
+
+    assert!(
+        matches!(result, Err(Error::Runtime(_))),
+        "program should fail at VM runtime, got {result:?}",
+    );
 }
 
 #[test]

--- a/crates/lean_vm/src/diagnostics/stack_trace.rs
+++ b/crates/lean_vm/src/diagnostics/stack_trace.rs
@@ -1,15 +1,33 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use backend::ToUsize;
+use backend::ansi::Colorize;
+
+use crate::diagnostics::RunnerError;
+use crate::execution::memory::MemoryAccess;
 use crate::isa::Bytecode;
 use crate::{CodeAddress, FunctionName, SourceLocation};
-use backend::ansi::Colorize;
-use std::collections::BTreeMap;
 
-pub(crate) fn pretty_stack_trace(
+const MAX_STACK_FRAMES: usize = 256;
+
+struct StackFrame {
+    function: FunctionName,
+    location: SourceLocation,
+    pc: CodeAddress,
+    fp: usize,
+    return_pc: Option<CodeAddress>,
+}
+
+pub(crate) fn pretty_stack_trace<M: MemoryAccess>(
     bytecode: &Bytecode,
     error_pc: CodeAddress,
-    location_history: &[SourceLocation],
+    error_fp: usize,
+    memory: &M,
+    error: &RunnerError,
 ) -> String {
     let mut out = String::new();
-    let error_loc = bytecode.debug_info().pc_to_location.get(error_pc).copied();
+    let error_loc =
+        error_source_location(error).or_else(|| bytecode.debug_info().pc_to_location.get(error_pc).copied());
 
     out.push_str(&format!("{}\n\n", "ERROR".red().bold()));
 
@@ -59,19 +77,32 @@ pub(crate) fn pretty_stack_trace(
         }
     }
 
-    // Call stack
-    let stack = build_call_stack(location_history, &bytecode.debug_info().function_locations);
-    if stack.len() > 1 {
+    let (stack, truncated) = build_call_stack(bytecode, error_pc, error_fp, memory, error_loc);
+    let visible_stack: Vec<_> = stack
+        .iter()
+        .filter(|frame| !is_generated_loop_function(&frame.function))
+        .collect();
+    if !visible_stack.is_empty() {
         out.push_str(&format!("\n{}\n\n", "CALL STACK".yellow().bold()));
-        for (i, (func, call_loc)) in stack.iter().rev().enumerate() {
-            let path = filepath(bytecode, call_loc.file_id);
+        for (i, frame) in visible_stack.iter().enumerate() {
+            let path = filepath(bytecode, frame.location.file_id);
             let marker = if i == 0 { "→".red().to_string() } else { " ".into() };
+            let return_pc = frame.return_pc.map(|pc| format!(" return_pc={pc}")).unwrap_or_default();
             out.push_str(&format!(
-                "  {} {} at {}:{}\n",
+                "  {} {} at {}:{} pc={} fp={}{}\n",
                 marker,
-                format!("{func}()").bold(),
+                format!("{}()", frame.function).bold(),
                 path.dimmed(),
-                call_loc.line_number.to_string().dimmed()
+                frame.location.line_number.to_string().dimmed(),
+                frame.pc,
+                frame.fp,
+                return_pc,
+            ));
+        }
+        if truncated {
+            out.push_str(&format!(
+                "    {}\n",
+                format!("stack trace truncated after {MAX_STACK_FRAMES} frames").dimmed()
             ));
         }
     }
@@ -79,25 +110,89 @@ pub(crate) fn pretty_stack_trace(
     out
 }
 
-fn build_call_stack(
-    history: &[SourceLocation],
-    func_locs: &BTreeMap<SourceLocation, String>,
-) -> Vec<(String, SourceLocation)> {
-    let mut stack: Vec<(String, SourceLocation)> = Vec::new();
+fn build_call_stack<M: MemoryAccess>(
+    bytecode: &Bytecode,
+    error_pc: CodeAddress,
+    error_fp: usize,
+    memory: &M,
+    error_loc: Option<SourceLocation>,
+) -> (Vec<StackFrame>, bool) {
+    let mut stack = Vec::new();
+    let error_loc = error_loc.unwrap_or_else(unknown_location);
+    let (_, current_function) = find_function_for_location(error_loc, &bytecode.debug_info().function_locations);
+    stack.push(StackFrame {
+        function: current_function,
+        location: error_loc,
+        pc: error_pc,
+        fp: error_fp,
+        return_pc: None,
+    });
 
-    for (i, &loc) in history.iter().enumerate() {
-        let (_, func) = find_function_for_location(loc, func_locs);
-
-        if stack.last().map(|(f, _)| f) != Some(&func) {
-            if let Some(pos) = stack.iter().position(|(f, _)| f == &func) {
-                stack.truncate(pos + 1);
-            } else {
-                let call_loc = if i > 0 { history[i - 1] } else { loc };
-                stack.push((func, call_loc));
-            }
+    let mut fp = error_fp;
+    let mut seen_fps = BTreeSet::new();
+    while stack.len() < MAX_STACK_FRAMES {
+        if !seen_fps.insert(fp) {
+            break;
         }
+
+        let Ok(return_pc) = memory.get(fp).map(|value| value.to_usize()) else {
+            break;
+        };
+        let Ok(saved_fp) = memory.get(fp + 1).map(|value| value.to_usize()) else {
+            break;
+        };
+
+        let frame = if let Some(call_site) = bytecode.debug_info().call_sites_by_return_pc.get(&return_pc) {
+            StackFrame {
+                function: call_site.caller.clone(),
+                location: call_site.location,
+                pc: call_site.call_pc,
+                fp: saved_fp,
+                return_pc: Some(call_site.return_pc),
+            }
+        } else {
+            let caller_pc = return_pc.saturating_sub(1);
+            let loc = bytecode
+                .debug_info()
+                .pc_to_location
+                .get(caller_pc)
+                .copied()
+                .unwrap_or_else(unknown_location);
+            let (_, function) = find_function_for_location(loc, &bytecode.debug_info().function_locations);
+            StackFrame {
+                function,
+                location: loc,
+                pc: caller_pc,
+                fp: saved_fp,
+                return_pc: Some(return_pc),
+            }
+        };
+        stack.push(frame);
+
+        if saved_fp == fp {
+            return (stack, false);
+        }
+        fp = saved_fp;
     }
-    stack
+
+    let truncated = stack.len() == MAX_STACK_FRAMES
+        && !seen_fps.contains(&fp)
+        && memory.get(fp).is_ok()
+        && memory.get(fp + 1).is_ok();
+    (stack, truncated)
+}
+
+fn is_generated_loop_function(function: &str) -> bool {
+    function.starts_with("@loop_") || function.starts_with("@parallel_loop_")
+}
+
+fn error_source_location(error: &RunnerError) -> Option<SourceLocation> {
+    match error {
+        RunnerError::DebugAssertFailed(_, location) | RunnerError::RangeCheckWithTooBigRange { location, .. } => {
+            Some(*location)
+        }
+        _ => None,
+    }
 }
 
 pub(crate) fn find_function_for_location(
@@ -115,6 +210,13 @@ pub(crate) fn find_function_for_location(
             },
             "<unknown>".into(),
         ))
+}
+
+fn unknown_location() -> SourceLocation {
+    SourceLocation {
+        file_id: 0,
+        line_number: 0,
+    }
 }
 
 fn filepath(bytecode: &Bytecode, file_id: usize) -> &str {

--- a/crates/lean_vm/src/execution/runner.rs
+++ b/crates/lean_vm/src/execution/runner.rs
@@ -18,6 +18,64 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use super::memory::SegmentMemory;
 
+#[derive(Debug, Clone, Copy)]
+pub struct ExecutionOptions {
+    /// Include VM profiling metadata in the execution result.
+    pub profiling: bool,
+    /// Print a source-level stack trace to stderr when execution fails.
+    pub stack_trace: bool,
+}
+
+impl ExecutionOptions {
+    /// Preserve the legacy boolean profiler API while allowing `LEANVM_STACK_TRACE=0`
+    /// to disable stack traces without changing callers.
+    pub fn from_profiling(profiling: bool) -> Self {
+        Self {
+            profiling,
+            stack_trace: stack_trace_enabled_from_env(true),
+        }
+    }
+}
+
+impl Default for ExecutionOptions {
+    fn default() -> Self {
+        Self {
+            profiling: false,
+            stack_trace: true,
+        }
+    }
+}
+
+struct ExecutionFailure {
+    err: RunnerError,
+    stack_trace: Option<String>,
+}
+
+impl ExecutionFailure {
+    fn new<M: MemoryAccess>(
+        bytecode: &Bytecode,
+        memory: &M,
+        pc: CodeAddress,
+        fp: usize,
+        err: RunnerError,
+        stack_trace: bool,
+    ) -> Self {
+        let stack_trace = stack_trace.then(|| crate::diagnostics::pretty_stack_trace(bytecode, pc, fp, memory, &err));
+        Self { err, stack_trace }
+    }
+}
+
+fn stack_trace_enabled_from_env(default: bool) -> bool {
+    match std::env::var("LEANVM_STACK_TRACE") {
+        Ok(value) => match value.trim().to_ascii_lowercase().as_str() {
+            "0" | "false" | "off" | "no" => false,
+            "1" | "true" | "on" | "yes" => true,
+            _ => default,
+        },
+        Err(_) => default,
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct ExecutionWitness {
     /// Length of the program's "preamble memory" — a region between public
@@ -62,6 +120,20 @@ pub fn try_execute_bytecode(
     witness: &ExecutionWitness,
     profiling: bool,
 ) -> Result<ExecutionResult, RunnerError> {
+    try_execute_bytecode_with_options(
+        bytecode,
+        public_input,
+        witness,
+        ExecutionOptions::from_profiling(profiling),
+    )
+}
+
+pub fn try_execute_bytecode_with_options(
+    bytecode: &Bytecode,
+    public_input: &[F; PUBLIC_INPUT_LEN],
+    witness: &ExecutionWitness,
+    options: ExecutionOptions,
+) -> Result<ExecutionResult, RunnerError> {
     let mut std_out = String::new();
     let mut instruction_history = ExecutionHistory::new();
     execute_bytecode_helper(
@@ -70,20 +142,19 @@ pub fn try_execute_bytecode(
         witness,
         &mut std_out,
         &mut instruction_history,
-        profiling,
+        options,
     )
-    .map_err(|(last_pc, err)| {
-        eprintln!(
-            "\n{}",
-            crate::diagnostics::pretty_stack_trace(bytecode, last_pc, &instruction_history.lines)
-        );
+    .map_err(|failure| {
+        if let Some(stack_trace) = failure.stack_trace {
+            eprintln!("\n{stack_trace}");
+        }
         if !std_out.is_empty() {
             eprintln!("╔══════════════════════════════════════════════════════════════╗");
             eprintln!("║                         STD-OUT                              ║");
             eprintln!("╚══════════════════════════════════════════════════════════════╝\n");
             eprint!("{std_out}");
         }
-        err
+        failure.err
     })
 }
 
@@ -146,6 +217,13 @@ struct ParallelBatchInfo {
     /// hints. Diffed against the post-iteration-0 state to learn per-name
     /// consumption.
     hint_indices_at_start: Vec<usize>,
+}
+
+struct ParallelSegmentFailure {
+    segment_id: usize,
+    pc: CodeAddress,
+    fp: usize,
+    err: RunnerError,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -272,8 +350,8 @@ fn execute_bytecode_helper(
     witness: &ExecutionWitness,
     std_out: &mut String,
     instruction_history: &mut ExecutionHistory,
-    profiling: bool,
-) -> Result<ExecutionResult, (CodeAddress, RunnerError)> {
+    options: ExecutionOptions,
+) -> Result<ExecutionResult, ExecutionFailure> {
     let n_slots = bytecode.n_hint_slots();
     let hint_data = &witness.hints;
     let mut hint_indices = vec![0usize; n_slots];
@@ -312,7 +390,7 @@ fn execute_bytecode_helper(
             hint_data,
             None,
         )
-        .map_err(|e| (pc, e))?
+        .map_err(|e| ExecutionFailure::new(bytecode, &memory, pc, fp, e, options.stack_trace))?
         {
             LoopExit::Halted => break,
             LoopExit::ParallelBatch(batch) => {
@@ -326,25 +404,30 @@ fn execute_bytecode_helper(
                     &mut fp,
                     &mut ap,
                     &batch,
-                )
-                .map_err(|e| (pc, e))?;
+                    options.stack_trace,
+                )?;
             }
             LoopExit::LoopBack => unreachable!("main loop has no stop_pc"),
         }
     }
 
-    resolve_deref_hints(&mut memory, &trace.pending_deref_hints).map_err(|e| (pc, e))?;
+    resolve_deref_hints(&mut memory, &trace.pending_deref_hints)
+        .map_err(|e| ExecutionFailure::new(bytecode, &memory, pc, fp, e, options.stack_trace))?;
     assert_eq!(pc, bytecode.ending_pc());
     for (slot, hint) in hint_data.0.iter().enumerate() {
         if hint_indices[slot] != hint.entries.len() {
-            return Err((
+            return Err(ExecutionFailure::new(
+                bytecode,
+                &memory,
                 pc,
+                fp,
                 RunnerError::InvalidHintWitness(format!(
                     "not all entries of named hint '{}' were consumed ({} of {} used)",
                     hint.name,
                     hint_indices[slot],
                     hint.entries.len(),
                 )),
+                options.stack_trace,
             ));
         }
     }
@@ -352,7 +435,7 @@ fn execute_bytecode_helper(
     trace.fps.push(fp);
 
     let no_vec_runtime_memory = ap - initial_ap;
-    let profiling_report = if profiling {
+    let profiling_report = if options.profiling {
         Some(crate::diagnostics::profiling_report(
             instruction_history,
             &bytecode.debug_info().function_locations,
@@ -417,20 +500,38 @@ fn handle_parallel_batch(
     fp: &mut usize,
     ap: &mut usize,
     batch: &ParallelBatchInfo,
-) -> Result<(), RunnerError> {
-    let start_value = memory.get(batch.batch_fp + 2)?.to_usize();
-    let end_value = batch.end_value.read_value(memory, batch.batch_fp)?.to_usize();
+    stack_trace: bool,
+) -> Result<(), ExecutionFailure> {
+    let start_value = memory
+        .get(batch.batch_fp + 2)
+        .map_err(|e| ExecutionFailure::new(bytecode, memory, *pc, *fp, e, stack_trace))?
+        .to_usize();
+    let end_value = batch
+        .end_value
+        .read_value(memory, batch.batch_fp)
+        .map_err(|e| ExecutionFailure::new(bytecode, memory, *pc, *fp, e, stack_trace))?
+        .to_usize();
     let n_iters = end_value.saturating_sub(start_value);
     if n_iters <= 1 {
         return Ok(());
     }
 
     let stride = *fp - batch.batch_fp;
-    let return_pc = memory.get(*fp)?.to_usize();
-    let saved_fp = memory.get(*fp + 1)?.to_usize();
+    let return_pc = memory
+        .get(*fp)
+        .map_err(|e| ExecutionFailure::new(bytecode, memory, *pc, *fp, e, stack_trace))?
+        .to_usize();
+    let saved_fp = memory
+        .get(*fp + 1)
+        .map_err(|e| ExecutionFailure::new(bytecode, memory, *pc, *fp, e, stack_trace))?
+        .to_usize();
     let args: Vec<F> = (0..batch.n_args)
-        .map(|i| memory.get(batch.batch_fp + 2 + i).unwrap())
-        .collect();
+        .map(|i| {
+            memory
+                .get(batch.batch_fp + 2 + i)
+                .map_err(|e| ExecutionFailure::new(bytecode, memory, *pc, *fp, e, stack_trace))
+        })
+        .collect::<Result<_, _>>()?;
 
     let named_per_iter: Vec<usize> = hints
         .indices
@@ -449,12 +550,20 @@ fn handle_parallel_batch(
             saved_fp,
             iter_val,
             &args,
-        )?;
+        )
+        .map_err(|e| ExecutionFailure::new(bytecode, memory, *pc, *fp, e, stack_trace))?;
     }
 
     let max_addr = batch.batch_fp + (n_iters + 1) * stride;
     if max_addr > 1 << MAX_LOG_MEMORY_SIZE {
-        return Err(RunnerError::OutOfMemory);
+        return Err(ExecutionFailure::new(
+            bytecode,
+            memory,
+            *pc,
+            *fp,
+            RunnerError::OutOfMemory,
+            stack_trace,
+        ));
     }
     if max_addr > memory.0.len() {
         memory.0.resize(max_addr, None);
@@ -470,7 +579,7 @@ fn handle_parallel_batch(
     let shared: &[Option<F>] = &*left;
     let mut segment_slices: Vec<&mut [Option<F>]> = right.chunks_mut(stride).take(n_par).collect();
 
-    type SegResult = Result<(Trace, Vec<(usize, F)>), RunnerError>;
+    type SegResult = Result<(Trace, Vec<(usize, F)>), ParallelSegmentFailure>;
 
     let seg_info: Vec<(parallel::SendPtr<Option<F>>, usize)> = segment_slices
         .iter_mut()
@@ -506,27 +615,49 @@ fn handle_parallel_batch(
             &mut seg_hints,
             hint_data,
             Some(batch.batch_pc),
-        )?;
+        )
+        .map_err(|err| ParallelSegmentFailure {
+            segment_id: i + 1,
+            pc: seg_pc,
+            fp: seg_fp,
+            err,
+        })?;
         for slot in 0..seg_indices.len() {
             let delta = named_per_iter[slot];
             // Before `run_loop` this segment was at `base_indices[slot] + i*delta`.
             let consumed = seg_indices[slot] - (base_indices[slot] + i * delta);
             if consumed != delta {
                 let name = hint_data.name(slot);
-                return Err(RunnerError::InvalidHintWitness(format!(
-                    "hint '{name}' consumed {consumed} entries in a parallel iteration but {delta} in iteration 0; parallel iterations must consume hints uniformly"
-                )));
+                return Err(ParallelSegmentFailure {
+                    segment_id: i + 1,
+                    pc: seg_pc,
+                    fp: seg_fp,
+                    err: RunnerError::InvalidHintWitness(format!(
+                        "hint '{name}' consumed {consumed} entries in a parallel iteration but {delta} in iteration 0; parallel iterations must consume hints uniformly"
+                    )),
+                });
             }
         }
         let deferred = seg_mem.into_deferred_writes();
         Ok((seg_trace, deferred))
     });
 
-    for (idx, result) in results.into_iter().enumerate() {
-        let (seg_trace, deferred) = result.map_err(|e| RunnerError::ParallelSegmentFailed(idx + 1, Box::new(e)))?;
+    for result in results {
+        let (seg_trace, deferred) = result.map_err(|failure| {
+            ExecutionFailure::new(
+                bytecode,
+                memory,
+                failure.pc,
+                failure.fp,
+                RunnerError::ParallelSegmentFailed(failure.segment_id, Box::new(failure.err)),
+                stack_trace,
+            )
+        })?;
         trace.merge(seg_trace);
         for (addr, val) in deferred {
-            memory.set(addr, val)?;
+            memory
+                .set(addr, val)
+                .map_err(|e| ExecutionFailure::new(bytecode, memory, *pc, *fp, e, stack_trace))?;
         }
     }
 

--- a/crates/lean_vm/src/isa/bytecode.rs
+++ b/crates/lean_vm/src/isa/bytecode.rs
@@ -2,7 +2,7 @@
 
 use backend::*;
 
-use crate::{DIMENSION, F, FileId, FunctionName, Hint, N_INSTRUCTION_COLUMNS, SourceLocation};
+use crate::{CodeAddress, DIMENSION, F, FileId, FunctionName, Hint, N_INSTRUCTION_COLUMNS, SourceLocation};
 
 use super::Instruction;
 use super::encoder::field_representation;
@@ -15,6 +15,15 @@ pub struct CodeEntry {
     pub instruction: Instruction,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CallSite {
+    pub caller: FunctionName,
+    pub callee: FunctionName,
+    pub location: SourceLocation,
+    pub call_pc: CodeAddress,
+    pub return_pc: CodeAddress,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct BytecodeDebugInfo {
     pub function_locations: BTreeMap<SourceLocation, FunctionName>,
@@ -22,6 +31,8 @@ pub struct BytecodeDebugInfo {
     pub source_code: BTreeMap<FileId, String>,
     /// Maps each pc to its source location
     pub pc_to_location: Vec<SourceLocation>,
+    /// Maps a function-call continuation pc to source-level call-site metadata.
+    pub call_sites_by_return_pc: BTreeMap<CodeAddress, CallSite>,
 }
 
 /// `instructions_multilinear`, `hash`, and `ending_pc` must be checked at initialization to match `code`.


### PR DESCRIPTION
## Summary

- add source-level call-site metadata to compiled bytecode so runtime failures can reconstruct caller/callee frames from the VM frame chain
- replace history-based stack guessing with a bounded, cycle-safe `fp` unwinder that prints frames from the failing function back to `main`
- add `ExecutionOptions` / `CompileAndRunOptions` plus `LEANVM_STACK_TRACE=0` for legacy callers to disable stack trace printing
- preserve worker-local `pc`/`fp` for `parallel_range` failures and hide compiler-generated loop helper frames from the rendered stack

Closes #112.

## Root cause

The existing diagnostic path inferred call stacks from source-location history. That could show useful source context, but it was not organized by the live caller/callee relation and could not reliably print the current VM frame chain from the failing function back to `main`.

## Implementation notes

Touched surfaces:

- `crates/lean_compiler/src/b_compile_intermediate.rs`
- `crates/lean_compiler/src/c_compile_final.rs`
- `crates/lean_compiler/src/ir/instruction.rs`
- `crates/lean_compiler/src/lib.rs`
- `crates/lean_compiler/tests/test_compiler.rs`
- `crates/lean_vm/src/diagnostics/stack_trace.rs`
- `crates/lean_vm/src/execution/runner.rs`
- `crates/lean_vm/src/isa/bytecode.rs`

The unwinder follows the VM call convention (`mem[fp] = return_pc`, `mem[fp + 1] = saved_fp`) and has three safety guards: a 256-frame cap, repeated-`fp` detection, and checked memory reads. If the cap is hit while another frame is readable, the rendered trace includes a truncation marker.

`Bytecode` gains debug-only call-site metadata in `call_sites_by_return_pc`. I checked repository serialization usage: `Bytecode` does not derive or implement serde serialization/deserialization, and aggregation bytecode is compiled into a `OnceLock` at runtime rather than loaded from a persisted bytecode blob.

## Sequencing / collision notes

This intentionally opens as a draft because the collision surface is real:

- #239 touches `crates/lean_vm/src/execution/runner.rs` and `crates/lean_compiler/src/c_compile_final.rs`, including parallel execution work.
- #210 touches `runner.rs`, `c_compile_final.rs`, and `test_compiler.rs`.
- #245 overlaps `crates/lean_compiler/src/lib.rs`; if #245 lands first, this should be rebased before review.

## Validation

- `cargo test -p lean_compiler runtime_failure -- --nocapture`
- `cargo test -p lean_compiler`
- `cargo fmt --check`
- `git diff --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
